### PR TITLE
Enabled support for PHP 7.4 after user feedback

### DIFF
--- a/.changeset/curly-lobsters-design.md
+++ b/.changeset/curly-lobsters-design.md
@@ -1,0 +1,8 @@
+---
+"wptelegram": patch
+"wptelegram-comments": patch
+"wptelegram-login": patch
+"wptelegram-widget": patch
+---
+
+Enabled support for PHP 7.4 after user feedback

--- a/config/wpdev.base.project.js
+++ b/config/wpdev.base.project.js
@@ -18,7 +18,7 @@ export const getBundleConfig = ({ slug, key, version, textDomain }) => {
 				type: 'update-requirements',
 				data: {
 					requirements: {
-						requiresPHP: '8.0',
+						requiresPHP: '7.4',
 						requiresAtLeast: '6.2',
 						testedUpTo: '6.4.1',
 					},


### PR DESCRIPTION
Many users reached out to us on Telegram after we made PHP 8.0 the minimum required version. Many users can't update to PHP 8.0 yet due to many plugins not supporting it yet.

So, this PR makes the minimum PHP required to be 7.4