### PR TITLE
Fix PHP 7.4 critical error on settings page

### DIFF
--- a/.changeset/dry-bags-marry.md
+++ b/.changeset/dry-bags-marry.md
@@ -1,0 +1,5 @@
+---
+"wptelegram": patch
+---
+
+Fixed PHP 7.4 critical error on settings page

--- a/.changeset/thick-walls-exist.md
+++ b/.changeset/thick-walls-exist.md
@@ -1,0 +1,6 @@
+---
+"wptelegram-widget": patch
+"wptelegram": patch
+---
+
+Fixed PHP notice on plugins page requirements

--- a/plugins/wptelegram-widget/src/includes/Requirements.php
+++ b/plugins/wptelegram-widget/src/includes/Requirements.php
@@ -58,7 +58,7 @@ class Requirements extends \WPSocio\WPUtils\Requirements {
 
 		$missing = [];
 
-		foreach ( $env_details['data']['PHP']['extensions'] as $extension => $loaded ) {
+		foreach ( $env_details['PHP']['extensions'] as $extension => $loaded ) {
 			if ( ! $loaded ) {
 				$missing[] = $extension;
 			}

--- a/plugins/wptelegram/src/includes/AssetManager.php
+++ b/plugins/wptelegram/src/includes/AssetManager.php
@@ -168,12 +168,14 @@ class AssetManager extends BaseClass {
 
 			$data['savedSettings'] = SettingsController::get_default_settings();
 
-			$data['assets'] = [
-				...$data['assets'],
-				'editProfileUrl' => get_edit_profile_url( get_current_user_id() ),
-				'p2tgLogUrl'     => Logger::get_log_url( 'p2tg' ),
-				'botApiLogUrl'   => Logger::get_log_url( 'bot-api' ),
-			];
+			$data['assets'] = array_merge(
+				$data['assets'],
+				[
+					'editProfileUrl' => get_edit_profile_url( get_current_user_id() ),
+					'p2tgLogUrl'     => Logger::get_log_url( 'p2tg' ),
+					'botApiLogUrl'   => Logger::get_log_url( 'bot-api' ),
+				]
+			);
 		}
 
 		return apply_filters( 'wptelegram_inline_script_data', $data, $for, $this->plugin() );

--- a/plugins/wptelegram/src/includes/Requirements.php
+++ b/plugins/wptelegram/src/includes/Requirements.php
@@ -58,7 +58,7 @@ class Requirements extends \WPSocio\WPUtils\Requirements {
 
 		$missing = [];
 
-		foreach ( $env_details['data']['PHP']['extensions'] as $extension => $loaded ) {
+		foreach ( $env_details['PHP']['extensions'] as $extension => $loaded ) {
 			if ( ! $loaded ) {
 				$missing[] = $extension;
 			}

--- a/plugins/wptelegram/src/modules/p2tg/Admin.php
+++ b/plugins/wptelegram/src/modules/p2tg/Admin.php
@@ -131,13 +131,15 @@ class Admin extends BaseClass {
 	public function update_inline_script_data( $data, $for ) {
 
 		if ( AssetManager::ADMIN_SETTINGS_ENTRY === $for ) {
-			$data['uiData'] = [
-				...$data['uiData'],
-				'post_types'          => $this->get_post_type_options(),
-				'macros'              => $this->get_macros(),
-				'rule_types'          => Rules::get_rule_types(),
-				'is_wp_cron_disabled' => defined( 'DISABLE_WP_CRON' ) && constant( 'DISABLE_WP_CRON' ),
-			];
+			$data['uiData'] = array_merge(
+				$data['uiData'],
+				[
+					'post_types'          => $this->get_post_type_options(),
+					'macros'              => $this->get_macros(),
+					'rule_types'          => Rules::get_rule_types(),
+					'is_wp_cron_disabled' => defined( 'DISABLE_WP_CRON' ) && constant( 'DISABLE_WP_CRON' ),
+				]
+			);
 		} elseif ( AssetManager::P2TG_BLOCK_EDITOR_ENTRY === $for ) {
 
 			$blocks_fields  = [

--- a/tools/wpdev/package.json
+++ b/tools/wpdev/package.json
@@ -18,7 +18,7 @@
 		"bin",
 		"dist",
 		"src",
-		"/oclif.manifest.json"
+		"oclif.manifest.json"
 	],
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Fix

```
Fatal error: Uncaught Error: Cannot unpack array with string keys in
/wp-projects/plugins/wptelegram/includes/AssetManager.php on line 172
```

Also fixed PHP notice on plugins page requirements about unknown array index - `extensions`