### PR TITLE
Replace `init` with `parse_query` for catching the login request

### DIFF
--- a/.changeset/witty-donuts-speak.md
+++ b/.changeset/witty-donuts-speak.md
@@ -1,0 +1,5 @@
+---
+"wptelegram-login": patch
+---
+
+Fixed the fatal error caused by other plugins on `init`

--- a/plugins/wptelegram-login/src/includes/Main.php
+++ b/plugins/wptelegram-login/src/includes/Main.php
@@ -388,7 +388,7 @@ class Main {
 
 		$login_handler = LoginHandler::instance();
 
-		add_action( 'init', [ $login_handler, 'telegram_login' ], 1 );
+		add_action( 'parse_query', [ $login_handler, 'telegram_login' ] );
 
 		$asset_manager = $this->asset_manager();
 


### PR DESCRIPTION
Right now the plugin uses `init` hook to catch the login requests. The problem with this hook is that many plugins use this hook to register their CPTs or taxonomies. Thus, if the login request is caught before a CPT or a taxonomy is registered, and the plugin tries to use it during the login request, it results in fatal error - example - https://wordpress.org/support/topic/bug-that-causes-fatal-errors

So, this PR replaces the `init` hook with `parse_query` hook to ensure that everything is initialized before the login request is intercepted.