### PR TITLE
Restore login intercept hook with a filter

### DIFF
--- a/plugins/wptelegram-login/src/includes/Main.php
+++ b/plugins/wptelegram-login/src/includes/Main.php
@@ -388,7 +388,9 @@ class Main {
 
 		$login_handler = LoginHandler::instance();
 
-		add_action( 'parse_query', [ $login_handler, 'telegram_login' ] );
+		list( $login_intercept_hook, $priority ) = apply_filters( 'wptelegram_login_intercept_request_on', [ 'init', 5 ] );
+
+		add_action( $login_intercept_hook, [ $login_handler, 'telegram_login' ], $priority );
 
 		$asset_manager = $this->asset_manager();
 


### PR DESCRIPTION
It reverses the changes made in #85 to restore the existing behavior and also provides a hook to decide which hook to use for interception.

So, if someone wants to change the hook, they can do so like this

```php
add_filter( 'wptelegram_login_intercept_request_on', function () {
    return [ 'parse_query', 10 ];
} );
```