### PR TITLE
Update the minimum required WP version for plugins

### DIFF
--- a/.changeset/rude-turtles-fix.md
+++ b/.changeset/rude-turtles-fix.md
@@ -1,0 +1,8 @@
+---
+"wptelegram": patch
+"wptelegram-comments": patch
+"wptelegram-login": patch
+"wptelegram-widget": patch
+---
+
+Updated minimum required WP version to 6.4

--- a/config/wpdev.base.project.js
+++ b/config/wpdev.base.project.js
@@ -19,7 +19,7 @@ export const getBundleConfig = ({ slug, key, version, textDomain }) => {
 				data: {
 					requirements: {
 						requiresPHP: '7.4',
-						requiresAtLeast: '6.2',
+						requiresAtLeast: '6.4',
 						testedUpTo: '6.4.3',
 					},
 					target: {


### PR DESCRIPTION
One of our users [reported that the settings page is blank](https://wordpress.org/support/topic/settings-page-empty-9/). Upon investigating, we found that the user was on WP 6.3.3 and we had mentioned the minimum requirement to be WP 6.2.

The reason for that blank page was that the settings JS script needs `type="module"` attribute which is set by `WPSocio\WPUtils\ViteWPReactAssets`.

`WPSocio\WPUtils\ViteWPReactAssets` uses [`wp_script_attributes`](https://developer.wordpress.org/reference/hooks/wp_script_attributes) filter (used by [`wp_get_script_tag`](https://developer.wordpress.org/reference/functions/wp_get_script_tag/)) that WordPress [falsely mentions to be available since WP 5.7](https://developer.wordpress.org/reference/hooks/wp_script_attributes/#changelog), while in reality it is used only [since WP 6.4](https://github.com/WordPress/wordpress-develop/blob/6.4/src/wp-includes/class-wp-scripts.php#L428-L430) and it is not available [till WP 6.3.3](https://github.com/WordPress/wordpress-develop/blob/6.3.3/src/wp-includes/class-wp-scripts.php#L412-L421).

Thus, we are changing the minimum WP requirement to 6.4.