### PR TITLE
Replace deprecated `FocusableIframe` by `useFocusableIframe`

### DIFF
--- a/.changeset/flat-years-thank.md
+++ b/.changeset/flat-years-thank.md
@@ -1,0 +1,5 @@
+---
+"wptelegram-widget": patch
+---
+
+Fixed the deprecation warning for `FocusableIframe`

--- a/.changeset/loud-seahorses-bathe.md
+++ b/.changeset/loud-seahorses-bathe.md
@@ -1,0 +1,5 @@
+---
+"wptelegram-widget": patch
+---
+
+Fixed the single post widget styles in post editor

--- a/plugins/wptelegram-widget/js/public/index.ts
+++ b/plugins/wptelegram-widget/js/public/index.ts
@@ -10,7 +10,7 @@ $(() => {
 		const height = $this.contents().find('body').height();
 
 		if (height) {
-			// Add 2px to the height to avoid hiddern borders
+			// Add 2px to the height to avoid hidden borders
 			$this.height((height + 2).toString());
 		}
 	});

--- a/plugins/wptelegram-widget/src/includes/Main.php
+++ b/plugins/wptelegram-widget/src/includes/Main.php
@@ -392,6 +392,7 @@ class Main {
 		add_action( 'init', [ $asset_manager, 'register_assets' ], 5 );
 
 		add_action( 'wp_enqueue_scripts', [ $asset_manager, 'enqueue_public_assets' ] );
+		add_action( 'admin_enqueue_scripts', [ $asset_manager, 'enqueue_public_assets' ] );
 
 		add_action( 'admin_enqueue_scripts', [ $asset_manager, 'enqueue_admin_assets' ] );
 


### PR DESCRIPTION
[`FocusableIframe`](https://github.com/WordPress/gutenberg/tree/280c5d7c138e4a5df15bc7e72a039f9d207ca532/packages/components/src/focusable-iframe#focusable-iframe) is deprecated with [`useFocusableIframe`](https://github.com/WordPress/gutenberg/blob/280c5d7c138e4a5df15bc7e72a039f9d207ca532/packages/compose/src/hooks/use-focusable-iframe/README.md) being the replacement.

This PR converts the Edit component of single-post block to functional component in order to use the new hook.