### PR TITLE
wpdev | Add make-php task to bundle command

### DIFF
--- a/.changeset/plenty-pumas-design.md
+++ b/.changeset/plenty-pumas-design.md
@@ -1,0 +1,5 @@
+---
+"@wpsocio/wpdev": minor
+---
+
+Added `make-php` task to `bundle` command

--- a/.changeset/young-jobs-tell.md
+++ b/.changeset/young-jobs-tell.md
@@ -1,0 +1,8 @@
+---
+"wptelegram": patch
+"wptelegram-comments": patch
+"wptelegram-login": patch
+"wptelegram-widget": patch
+---
+
+Added php translation files for better performance with WP 6.5

--- a/config/wpdev.base.project.js
+++ b/config/wpdev.base.project.js
@@ -79,7 +79,7 @@ export const getBundleConfig = ({ slug, key, version, textDomain }) => {
 				},
 			},
 			{
-				type: 'generate-pot',
+				type: 'i18n-make-pot',
 				data: {
 					source: 'src',
 					textDomain,
@@ -99,19 +99,25 @@ export const getBundleConfig = ({ slug, key, version, textDomain }) => {
 				},
 			},
 			{
-				type: 'update-po-files',
+				type: 'i18n-update-po',
 				data: {
 					source: `src/languages/${slug}.pot`,
 				},
 			},
 			{
-				type: 'make-mo-files',
+				type: 'i18n-make-mo',
 				data: {
 					source: 'src/languages/',
 				},
 			},
 			{
-				type: 'js-pot-to-php',
+				type: 'i18n-make-php',
+				data: {
+					source: 'src/languages/',
+				},
+			},
+			{
+				type: 'i18n-js-pot-to-php',
 				data: {
 					potFile: 'src/languages/js-translations.pot',
 					textDomain,

--- a/tools/wpdev/src/commands/bundle.ts
+++ b/tools/wpdev/src/commands/bundle.ts
@@ -5,12 +5,7 @@ import chalk from 'chalk';
 import { Listr, ListrTask } from 'listr2';
 import { WithProjects } from '../base-commands/WithProjects.js';
 import { updateChangelog } from '../utils/changelog.js';
-import {
-	generatePotFile,
-	makeMoFiles,
-	potToPhp,
-	updatePoFiles,
-} from '../utils/i18n.js';
+import { makeMo, makePhp, makePot, potToPhp, updatePo } from '../utils/i18n.js';
 import { copyFiles, getDistIgnorePattern, zipDir } from '../utils/misc.js';
 import {
 	WPProject,
@@ -240,43 +235,57 @@ export default class Bundle extends WithProjects<typeof Bundle> {
 							},
 						};
 
-					case 'generate-pot':
+					case 'i18n-make-pot':
 						return {
-							title: 'Generate POT file',
+							title: 'I18N: Make POT',
 							task: async () => {
-								return await generatePotFile(projectDir, {
+								return await makePot(projectDir, {
 									textDomain: projectInfo.textDomain,
 									...taskData,
 								});
 							},
 						};
 
-					case 'update-po-files':
+					case 'i18n-update-po':
 						return {
-							title: 'Update PO files',
+							title: 'I18N: Update PO files',
 							task: async () => {
-								return await updatePoFiles(projectDir, {
+								return await updatePo(projectDir, {
 									source: `src/languages/${projectInfo.textDomain}.pot`,
 									...taskData,
 								});
 							},
 						};
 
-					case 'make-mo-files':
+					case 'i18n-make-mo':
 						return {
-							title: 'Make MO files',
+							title: 'I18N: Make MO files',
 							task: async () => {
-								const { source } = taskData;
+								const { source, destination } = taskData;
 
-								return await makeMoFiles(projectDir, {
+								return await makeMo(projectDir, {
 									source: source || 'src/languages/',
+									destination: destination,
 								});
 							},
 						};
 
-					case 'js-pot-to-php':
+					case 'i18n-make-php':
 						return {
-							title: 'JS POT to PHP',
+							title: 'I18N: Make PHP files',
+							task: async () => {
+								const { source, destination } = taskData;
+
+								return await makePhp(projectDir, {
+									source: source || 'src/languages/',
+									destination: destination,
+								});
+							},
+						};
+
+					case 'i18n-js-pot-to-php':
+						return {
+							title: 'I18N: JS POT to PHP',
 							task: async () => {
 								const { potFile, textDomain, phpFile } = taskData;
 

--- a/tools/wpdev/src/utils/i18n.ts
+++ b/tools/wpdev/src/utils/i18n.ts
@@ -40,7 +40,7 @@ export type GeneratePotFileConfig = Pick<
 	mergeFiles?: Array<string>;
 };
 
-export async function generatePotFile(
+export async function makePot(
 	cwd: string,
 	{
 		outFile,
@@ -90,7 +90,7 @@ export type UpdatePoFilesConfig = {
 	destination?: string;
 };
 
-export async function updatePoFiles(
+export async function updatePo(
 	cwd: string,
 	{ source, destination }: UpdatePoFilesConfig,
 ) {
@@ -98,10 +98,18 @@ export async function updatePoFiles(
 	return await $({ cwd })`wp i18n update-po ${source} ${dest}`;
 }
 
-export async function makeMoFiles(
+export async function makeMo(
 	cwd: string,
 	{ source, destination }: UpdatePoFilesConfig,
 ) {
 	const dest = destination || source;
 	return await $({ cwd })`wp i18n make-mo ${source} ${dest}`;
+}
+
+export async function makePhp(
+	cwd: string,
+	{ source, destination }: UpdatePoFilesConfig,
+) {
+	const dest = destination || source;
+	return await $({ cwd })`wp i18n make-php ${source} ${dest}`;
 }

--- a/tools/wpdev/src/utils/schema.ts
+++ b/tools/wpdev/src/utils/schema.ts
@@ -74,14 +74,6 @@ const jsPotToPhpData = z.object({
 		.describe('The text domain. Defaults to slug.'),
 });
 
-const makeMoFilesData = z.object({
-	source: z
-		.string()
-		.optional()
-		.default('src/languages/')
-		.describe('The source directory that contains the .po files.'),
-});
-
 const scriptsData = z
 	.array(z.string())
 	.describe('The list of npm scripts to run.');
@@ -101,6 +93,40 @@ const updatePoFilesData = z.object({
 		.optional()
 		.describe(
 			'The source POT file. Defaults to "src/languages/{text-domain}.pot"',
+		),
+	destination: z
+		.string()
+		.optional()
+		.describe(
+			'The destination directory for the PO files. Defaults to "src/languages/"',
+		),
+});
+
+const makeMoFilesData = z.object({
+	source: z
+		.string()
+		.optional()
+		.default('src/languages/')
+		.describe('The source directory that contains the .po files.'),
+	destination: z
+		.string()
+		.optional()
+		.describe(
+			'The destination directory for the .mo files. Defaults to the source directory.',
+		),
+});
+
+const makePhpFilesData = z.object({
+	source: z
+		.string()
+		.optional()
+		.default('src/languages/')
+		.describe('The source directory that contains the .po files.'),
+	destination: z
+		.string()
+		.optional()
+		.describe(
+			'The destination directory for the .php files. Defaults to the source directory.',
 		),
 });
 
@@ -203,19 +229,23 @@ export const bundleSchema = z
 					data: updateChangelogData,
 				}),
 				z.object({
-					type: z.literal('generate-pot'),
+					type: z.literal('i18n-make-pot'),
 					data: generatePotData,
 				}),
 				z.object({
-					type: z.literal('update-po-files'),
+					type: z.literal('i18n-update-po'),
 					data: updatePoFilesData,
 				}),
 				z.object({
-					type: z.literal('make-mo-files'),
+					type: z.literal('i18n-make-mo'),
 					data: makeMoFilesData,
 				}),
 				z.object({
-					type: z.literal('js-pot-to-php'),
+					type: z.literal('i18n-make-php'),
+					data: makePhpFilesData,
+				}),
+				z.object({
+					type: z.literal('i18n-js-pot-to-php'),
 					data: jsPotToPhpData,
 				}),
 				z.object({


### PR DESCRIPTION
This PR adds `make-php` task to the `bundle` command for `wpdev` CLI to allow [performant translation files for WP 6.5](https://make.wordpress.org/core/2024/02/27/i18n-improvements-6-5-performant-translations/).