### PR TITLE
Fix post excerpt filter in post data not working

### DIFF
--- a/.changeset/neat-parents-sit.md
+++ b/.changeset/neat-parents-sit.md
@@ -1,0 +1,5 @@
+---
+"wptelegram": patch
+---
+
+Fixed post excerpt filter in post data not working

--- a/plugins/wptelegram/src/modules/p2tg/PostData.php
+++ b/plugins/wptelegram/src/modules/p2tg/PostData.php
@@ -165,10 +165,10 @@ class PostData {
 
 				} else {
 
-					$field  = 'post_content' === $excerpt_source ? 'post_content' : 'post_excerpt';
-					$filter = 'post_content' === $excerpt_source ? 'the_content' : 'the_excerpt';
+					$post_field = 'post_content' === $excerpt_source ? 'post_content' : 'post_excerpt';
+					$filter     = 'post_content' === $excerpt_source ? 'the_content' : 'the_excerpt';
 
-					$excerpt = get_post_field( $field, $this->post );
+					$excerpt = get_post_field( $post_field, $this->post );
 
 					self::remove_autoembed_filter();
 


### PR DESCRIPTION
The source of the bug was that `$field` in the function body scope was overridden inside switch.