### PR TITLE
WP Telegram | Fix is post new logic for draft posts

### DIFF
--- a/.changeset/many-bottles-fold.md
+++ b/.changeset/many-bottles-fold.md
@@ -1,0 +1,5 @@
+---
+"wptelegram": patch
+---
+
+Fixed the is new post logic for draft posts

--- a/packages/php/telegram-format-text/src/Converter/ImageConverter.php
+++ b/packages/php/telegram-format-text/src/Converter/ImageConverter.php
@@ -30,7 +30,7 @@ class ImageConverter extends BaseConverter {
 			return $text;
 		}
 
-		// If the image is the only child of the parent link, return the image lint.
+		// If the image is the only child of the parent link, return the image link.
 		if ( $retainLoneImageLink && $this->isOnlyChildOfLink( $element ) ) {
 			return $src;
 		}

--- a/plugins/wptelegram/src/modules/p2tg/Utils.php
+++ b/plugins/wptelegram/src/modules/p2tg/Utils.php
@@ -41,8 +41,10 @@ class Utils {
 			return false;
 		}
 
+		$post_publish_time = get_post_time( 'U', true, $post->ID, false );
+
 		// if the post has been published more than one day ago.
-		$is_more_than_a_day_old = ( ( time() - get_post_time( 'U', true, $post->ID, false ) ) / DAY_IN_SECONDS ) > 1;
+		$is_more_than_a_day_old = $post_publish_time ? ( ( time() - $post_publish_time ) / DAY_IN_SECONDS ) > 1 : false;
 
 		// whether the post has already been sent to Telegram.
 		$sent2tg = get_post_meta( $post->ID, Main::PREFIX . 'sent2tg', true );


### PR DESCRIPTION
A user reported an issue where a draft post created by some other plugin resulted in the post being marked as not new and thus Send to Telegram option being unchecked by default for those posts.

This PR fixes that issue by confirming that the post time is not false (in case of draft posts).