### PR TITLE
Fix i18n for plugins

### DIFF
--- a/.changeset/calm-socks-cheer.md
+++ b/.changeset/calm-socks-cheer.md
@@ -1,0 +1,9 @@
+---
+"wptelegram": patch
+"wptelegram-comments": patch
+"wptelegram-login": patch
+"wptelegram-widget": patch
+"wptelegram-pro": patch
+---
+
+Fixed translations not working for settings page

--- a/.changeset/soft-islands-watch.md
+++ b/.changeset/soft-islands-watch.md
@@ -1,0 +1,5 @@
+---
+"@wpsocio/wp-utils": patch
+---
+
+Fixed JED format for translation strings

--- a/packages/php/wp-utils/src/Helpers.php
+++ b/packages/php/wp-utils/src/Helpers.php
@@ -207,7 +207,7 @@ class Helpers {
 		}
 
 		foreach ( $translations->entries as $msgid => $entry ) {
-			$locale[ $msgid ] = $entry->translations;
+			$locale[ is_int( $msgid ) ? $entry->singular : $msgid ] = $entry->translations;
 		}
 
 		return $locale;


### PR DESCRIPTION
A [user reported](https://wordpress.org/support/topic/plugin-language-16/#post-17872700) that the translations are not working for settings pages.