### PR TITLE
Fix WP Telegram logging

### DIFF
--- a/.changeset/stupid-geese-visit.md
+++ b/.changeset/stupid-geese-visit.md
@@ -1,0 +1,5 @@
+---
+"wptelegram": patch
+---
+
+Fixed logging to remove only the old entries when file size limit is reached.

--- a/config/wpdev.base.project.js
+++ b/config/wpdev.base.project.js
@@ -20,7 +20,7 @@ export const getBundleConfig = ({ slug, key, version, textDomain }) => {
 					requirements: {
 						requiresPHP: '7.4',
 						requiresAtLeast: '6.4',
-						testedUpTo: '6.5.2',
+						testedUpTo: '6.6',
 					},
 					target: {
 						files: [
@@ -112,12 +112,6 @@ export const getBundleConfig = ({ slug, key, version, textDomain }) => {
 			},
 			{
 				type: 'i18n-make-php',
-				data: {
-					source: 'src/languages/',
-				},
-			},
-			{
-				type: 'i18n-make-json',
 				data: {
 					source: 'src/languages/',
 				},


### PR DESCRIPTION
If the log file size reaches the maximum allowed file size, the previous content is discarded and the new content is added to the file. This sometimes results in fresh log entries being erased. This PR fixes that issue by removing only the old entries to keep the file size below the limit.