### PR TITLE
Remove translation for plugin title

### DIFF
--- a/.changeset/shiny-ears-care.md
+++ b/.changeset/shiny-ears-care.md
@@ -1,0 +1,8 @@
+---
+"wptelegram-comments": patch
+"wptelegram-widget": patch
+"wptelegram-login": patch
+"wptelegram": patch
+---
+
+Removed translation for plugin title to ensure the menu item it not invisible

--- a/plugins/wptelegram-comments/src/includes/Utils.php
+++ b/plugins/wptelegram-comments/src/includes/Utils.php
@@ -63,8 +63,8 @@ class Utils extends \WPSocio\WPUtils\Helpers {
 
 		if ( ! defined( 'WPTELEGRAM_LOADED' ) && empty( $admin_page_hooks['wptelegram'] ) ) {
 			add_menu_page(
-				__( 'WP Telegram', 'wptelegram-comments' ),
-				__( 'WP Telegram', 'wptelegram-comments' ),
+				'WP Telegram',
+				'WP Telegram',
 				'manage_options',
 				'wptelegram',
 				null,

--- a/plugins/wptelegram-login/src/admin/Admin.php
+++ b/plugins/wptelegram-login/src/admin/Admin.php
@@ -44,7 +44,7 @@ class Admin extends BaseClass {
 
 		$categories[] = [
 			'slug'  => $slug,
-			'title' => __( 'WP Telegram', 'wptelegram-login' ),
+			'title' => 'WP Telegram',
 			'icon'  => null,
 		];
 

--- a/plugins/wptelegram-login/src/includes/Utils.php
+++ b/plugins/wptelegram-login/src/includes/Utils.php
@@ -32,8 +32,8 @@ class Utils extends \WPSocio\WPUtils\Helpers {
 
 		if ( ! defined( 'WPTELEGRAM_LOADED' ) && empty( $admin_page_hooks['wptelegram'] ) ) {
 			add_menu_page(
-				__( 'WP Telegram', 'wptelegram-login' ),
-				__( 'WP Telegram', 'wptelegram-login' ),
+				'WP Telegram',
+				'WP Telegram',
 				'manage_options',
 				'wptelegram',
 				null,

--- a/plugins/wptelegram-widget/src/admin/Admin.php
+++ b/plugins/wptelegram-widget/src/admin/Admin.php
@@ -53,7 +53,7 @@ class Admin extends BaseClass {
 
 		$categories[] = [
 			'slug'  => $slug,
-			'title' => __( 'WP Telegram', 'wptelegram-widget' ),
+			'title' => 'WP Telegram',
 			'icon'  => null,
 		];
 

--- a/plugins/wptelegram-widget/src/includes/Utils.php
+++ b/plugins/wptelegram-widget/src/includes/Utils.php
@@ -276,8 +276,8 @@ class Utils {
 
 		if ( ! defined( 'WPTELEGRAM_LOADED' ) && empty( $admin_page_hooks['wptelegram'] ) ) {
 			add_menu_page(
-				__( 'WP Telegram', 'wptelegram-widget' ),
-				__( 'WP Telegram', 'wptelegram-widget' ),
+				'WP Telegram',
+				'WP Telegram',
 				'manage_options',
 				'wptelegram',
 				null,

--- a/plugins/wptelegram/src/includes/Main.php
+++ b/plugins/wptelegram/src/includes/Main.php
@@ -318,12 +318,7 @@ final class Main {
 	 * @return    string    The title of the plugin.
 	 */
 	public function title() {
-		// Set here instead of constructor
-		// to be able to translate it.
-		if ( ! $this->title ) {
-			$this->title = __( 'WP Telegram', 'wptelegram' );
-		}
-		return $this->title;
+		return 'WP Telegram';
 	}
 
 	/**


### PR DESCRIPTION
A [user reported](https://wordpress.org/support/topic/plugin-name-disappeared-some-posts-are-not-published/) that they can't see the plugin in admin menu.