### PR TITLE
Vite WP React: Externalize @wordpress/* dependencies dynamically for production

### DIFF
--- a/.changeset/calm-hotels-explain.md
+++ b/.changeset/calm-hotels-explain.md
@@ -1,0 +1,5 @@
+---
+"@wpsocio/vite-wp-react": patch
+---
+
+Externalize WP deps dynamically to ensure new dependencies are not left out

--- a/tools/vite-wp-react/src/plugins/externalize-wp-packages.ts
+++ b/tools/vite-wp-react/src/plugins/externalize-wp-packages.ts
@@ -1,7 +1,28 @@
 import rollupGlobals from 'rollup-plugin-external-globals';
 import type { PluginOption } from 'vite';
-import viteExternal from 'vite-plugin-external';
-import { WP_EXTERNAL_PACKAGES } from '../utils/index.js';
+import viteExternalPlugin from 'vite-plugin-external';
+import {
+	BUNDLED_WP_PACKAGES,
+	NON_WP_PACKAGES,
+	WP_EXTERNAL_PACKAGES,
+	dashToCamelCase,
+} from '../utils/index.js';
+
+const viteExternal =
+	// viteExternalPlugin is not typed well
+	viteExternalPlugin as unknown as (typeof viteExternalPlugin)['default'];
+
+function shouldExternalizePakage(name: string) {
+	if (BUNDLED_WP_PACKAGES.includes(name)) {
+		return false;
+	}
+
+	const isWpPackage = name.startsWith('@wordpress/');
+
+	const isNonWpPackage = name in NON_WP_PACKAGES;
+
+	return isWpPackage || isNonWpPackage;
+}
 
 /**
  * Updates the vite config to externalize all WordPress packages.
@@ -10,11 +31,17 @@ export const externalizeWpPackages = (): PluginOption => {
 	return [
 		{
 			name: 'vwpr:externalize-wp-packages',
-			config() {
+			config(config, { command }) {
+				// We need to run this only for the build command
+				if (command !== 'build') {
+					return {};
+				}
 				return {
 					build: {
 						rollupOptions: {
-							external: Object.keys(WP_EXTERNAL_PACKAGES),
+							external(source) {
+								return shouldExternalizePakage(source);
+							},
 							plugins: [
 								/**
 								 * Add the plugin to rollup to ensure react imports don't end up in the bundle
@@ -22,16 +49,41 @@ export const externalizeWpPackages = (): PluginOption => {
 								 *
 								 * @see https://github.com/vitejs/vite-plugin-react/issues/3
 								 */
-								rollupGlobals(WP_EXTERNAL_PACKAGES),
+								rollupGlobals((name) => {
+									if (!shouldExternalizePakage(name)) {
+										return '';
+									}
+
+									if (name in NON_WP_PACKAGES) {
+										return NON_WP_PACKAGES[name];
+									}
+
+									if (name.startsWith('@wordpress/')) {
+										const variable = dashToCamelCase(
+											name.replace('@wordpress/', ''),
+										);
+										return `wp.${variable}`;
+									}
+
+									return '';
+								}),
 							],
 						},
 					},
 				};
 			},
 		},
-		// @ts-ignore - viteExternal is not typed well
+		/**
+		 * We need this plugin only during development
+		 * To ensure that module aliases are created for external packages
+		 *
+		 * Change the externals list to dynamic if the below issue is resolved
+		 * @see https://github.com/fengxinming/vite-plugins/issues/44
+		 */
 		viteExternal({
-			externals: WP_EXTERNAL_PACKAGES,
+			development: {
+				externals: WP_EXTERNAL_PACKAGES,
+			},
 		}),
 	];
 };

--- a/tools/vite-wp-react/src/utils/wp-packages.ts
+++ b/tools/vite-wp-react/src/utils/wp-packages.ts
@@ -78,6 +78,12 @@ export const PACKAGE_HANDLES: Record<string, string> = {
 	'react-refresh/runtime': 'wp-react-refresh-runtime',
 };
 
+/**
+ * WordPress packages that are bundled.
+ *
+ * This list comes from Gutenberg
+ * @see https://github.com/WordPress/gutenberg/blob/313246a01f18e504dabd8313e7eacca728332bcd/packages/dependency-extraction-webpack-plugin/lib/util.js#L6
+ */
 export const BUNDLED_WP_PACKAGES = [
 	'@wordpress/dataviews',
 	'@wordpress/icons',

--- a/tools/vite-wp-react/src/utils/wp-packages.ts
+++ b/tools/vite-wp-react/src/utils/wp-packages.ts
@@ -67,7 +67,24 @@ export const NON_WP_PACKAGES: Record<string, string> = {
 	'react-dom': 'ReactDOM',
 	backbone: 'Backbone',
 	lodash: 'lodash',
+	'lodash-es': 'lodash',
+	'react/jsx-runtime': 'ReactJSXRuntime',
+	'react-refresh/runtime': 'ReactRefreshRuntime',
 };
+
+export const PACKAGE_HANDLES: Record<string, string> = {
+	'lodash-es': 'lodash',
+	'react/jsx-runtime': 'react-jsx-runtime',
+	'react-refresh/runtime': 'wp-react-refresh-runtime',
+};
+
+export const BUNDLED_WP_PACKAGES = [
+	'@wordpress/dataviews',
+	'@wordpress/icons',
+	'@wordpress/interface',
+	'@wordpress/sync',
+	'@wordpress/undo-manager',
+];
 
 export const WP_EXTERNAL_PACKAGES: Record<string, string> = {
 	...NON_WP_PACKAGES,


### PR DESCRIPTION
## Description

New packages are regularly added to `@wordpress/*` namespace and externalizing those packages is important for Vite WP React. So, instead of using a static list of packages, this PR updates it to use dynamic callbacks to decide whether to externalize a package or not.

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
