### PR TITLE
Restore translations for plugin name after l10n fix

### DIFF
--- a/.changeset/quiet-plums-refuse.md
+++ b/.changeset/quiet-plums-refuse.md
@@ -1,0 +1,8 @@
+---
+"wptelegram-comments": patch
+"wptelegram-widget": patch
+"wptelegram-login": patch
+"wptelegram": patch
+---
+
+Restored translations for plugin name after l10n fix

--- a/plugins/wptelegram-comments/src/includes/Utils.php
+++ b/plugins/wptelegram-comments/src/includes/Utils.php
@@ -63,8 +63,8 @@ class Utils extends \WPSocio\WPUtils\Helpers {
 
 		if ( ! defined( 'WPTELEGRAM_LOADED' ) && empty( $admin_page_hooks['wptelegram'] ) ) {
 			add_menu_page(
-				'WP Telegram',
-				'WP Telegram',
+				__( 'WP Telegram', 'wptelegram-comments' ),
+				__( 'WP Telegram', 'wptelegram-comments' ),
 				'manage_options',
 				'wptelegram',
 				null,

--- a/plugins/wptelegram-login/src/admin/Admin.php
+++ b/plugins/wptelegram-login/src/admin/Admin.php
@@ -44,7 +44,7 @@ class Admin extends BaseClass {
 
 		$categories[] = [
 			'slug'  => $slug,
-			'title' => 'WP Telegram',
+			'title' => __( 'WP Telegram', 'wptelegram-login' ),
 			'icon'  => null,
 		];
 

--- a/plugins/wptelegram-login/src/includes/Utils.php
+++ b/plugins/wptelegram-login/src/includes/Utils.php
@@ -32,8 +32,8 @@ class Utils extends \WPSocio\WPUtils\Helpers {
 
 		if ( ! defined( 'WPTELEGRAM_LOADED' ) && empty( $admin_page_hooks['wptelegram'] ) ) {
 			add_menu_page(
-				'WP Telegram',
-				'WP Telegram',
+				__( 'WP Telegram', 'wptelegram-login' ),
+				__( 'WP Telegram', 'wptelegram-login' ),
 				'manage_options',
 				'wptelegram',
 				null,

--- a/plugins/wptelegram-widget/src/admin/Admin.php
+++ b/plugins/wptelegram-widget/src/admin/Admin.php
@@ -53,7 +53,7 @@ class Admin extends BaseClass {
 
 		$categories[] = [
 			'slug'  => $slug,
-			'title' => 'WP Telegram',
+			'title' => __( 'WP Telegram', 'wptelegram-widget' ),
 			'icon'  => null,
 		];
 

--- a/plugins/wptelegram-widget/src/includes/Utils.php
+++ b/plugins/wptelegram-widget/src/includes/Utils.php
@@ -276,8 +276,8 @@ class Utils {
 
 		if ( ! defined( 'WPTELEGRAM_LOADED' ) && empty( $admin_page_hooks['wptelegram'] ) ) {
 			add_menu_page(
-				'WP Telegram',
-				'WP Telegram',
+				__( 'WP Telegram', 'wptelegram-widget' ),
+				__( 'WP Telegram', 'wptelegram-widget' ),
 				'manage_options',
 				'wptelegram',
 				null,

--- a/plugins/wptelegram/src/includes/Main.php
+++ b/plugins/wptelegram/src/includes/Main.php
@@ -318,7 +318,12 @@ final class Main {
 	 * @return    string    The title of the plugin.
 	 */
 	public function title() {
-		return 'WP Telegram';
+		// Set here instead of constructor
+		// to be able to translate it.
+		if ( ! $this->title ) {
+			$this->title = __( 'WP Telegram', 'wptelegram' );
+		}
+		return $this->title;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Some description here -->

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
