### PR TITLE
Revert externalization of react/jsx-runtime for backwards WP compatibility

### DIFF
--- a/.changeset/calm-hotel-explains.md
+++ b/.changeset/calm-hotel-explains.md
@@ -1,0 +1,5 @@
+---
+"@wpsocio/vite-wp-react": patch
+---
+
+Reverted externalization of react/jsx-runtime for backwards WP compatibility

--- a/.changeset/popular-raven-allows.md
+++ b/.changeset/popular-raven-allows.md
@@ -1,0 +1,8 @@
+---
+"wptelegram": patch
+"wptelegram-comments": patch
+"wptelegram-login": patch
+"wptelegram-widget": patch
+---
+
+Fixed settings page and post editor crash for older Wp versions

--- a/tools/vite-wp-react/src/utils/wp-packages.ts
+++ b/tools/vite-wp-react/src/utils/wp-packages.ts
@@ -74,8 +74,8 @@ export const NON_WP_PACKAGES: Record<string, string> = {
 
 export const PACKAGE_HANDLES: Record<string, string> = {
 	'lodash-es': 'lodash',
-	'react/jsx-runtime': 'react-jsx-runtime',
-	'react-refresh/runtime': 'wp-react-refresh-runtime',
+	// 'react/jsx-runtime': 'react-jsx-runtime',
+	// 'react-refresh/runtime': 'wp-react-refresh-runtime',
 };
 
 /**

--- a/tools/vite-wp-react/src/utils/wp-packages.ts
+++ b/tools/vite-wp-react/src/utils/wp-packages.ts
@@ -68,8 +68,8 @@ export const NON_WP_PACKAGES: Record<string, string> = {
 	backbone: 'Backbone',
 	lodash: 'lodash',
 	'lodash-es': 'lodash',
-	'react/jsx-runtime': 'ReactJSXRuntime',
-	'react-refresh/runtime': 'ReactRefreshRuntime',
+	// 'react/jsx-runtime': 'ReactJSXRuntime',
+	// 'react-refresh/runtime': 'ReactRefreshRuntime',
 };
 
 export const PACKAGE_HANDLES: Record<string, string> = {


### PR DESCRIPTION
<!--- Some description here -->

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
