### PR TITLE
Fix get attachment by filesize in WP Utils Helpers

### DIFF
--- a/.changeset/proud-bees-fetch.md
+++ b/.changeset/proud-bees-fetch.md
@@ -1,0 +1,5 @@
+---
+"wptelegram": patch
+---
+
+Fixed the issue of scaled image being preferred over original image

--- a/.changeset/tall-pugs-flow.md
+++ b/.changeset/tall-pugs-flow.md
@@ -1,0 +1,5 @@
+---
+"@wpsocio/wp-utils": patch
+---
+
+Fixed get attachment by filesize to return original image if within limits

--- a/packages/php/wp-utils/src/Helpers.php
+++ b/packages/php/wp-utils/src/Helpers.php
@@ -296,6 +296,13 @@ class Helpers {
 			return $path;
 		}
 
+		$original_image_path = function_exists( 'wp_get_original_image_path' ) ? wp_get_original_image_path( $id ) : null;
+
+		// If the original image is less than the limit.
+		if ( $original_image_path && is_readable( $original_image_path ) && filesize( $original_image_path ) <= $filesize ) {
+			return 'url' === $return ? wp_get_original_image_url( $id ) : $original_image_path;
+		}
+
 		$meta = wp_get_attachment_metadata( $id );
 
 		// For WP < 6.0.


### PR DESCRIPTION
A [user reported](https://t.me/WPTelegramChat/60044) that they see the scaled image being sent to Telegram instead of the original one when it's within the limits.

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
