### PR TITLE
Fix fatal during upgrade for WP Telegram

### DIFF
--- a/.changeset/plenty-dolphins-cross.md
+++ b/.changeset/plenty-dolphins-cross.md
@@ -1,0 +1,5 @@
+---
+"wptelegram": patch
+---
+
+Fixed the fatal error during upgrade

--- a/plugins/wptelegram/src/includes/Upgrade.php
+++ b/plugins/wptelegram/src/includes/Upgrade.php
@@ -396,7 +396,7 @@ class Upgrade extends BaseClass {
 	protected function upgrade_to_3_0_0() {
 		$main_options = get_option( 'wptelegram', [] );
 
-		$modules = reset( $main_options['modules'] );
+		$modules = ! empty( $main_options['modules'] ) && is_array( $main_options['modules'] ) ? reset( $main_options['modules'] ) : [];
 		unset( $modules['fake'] );
 
 		$active_modules = array_keys( $modules );


### PR DESCRIPTION
A [user reported a fatal error](https://wordpress.org/support/topic/upgrade-php-error/) caused during upgrade.

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
