### PR TITLE
Add multi-group support for legacy widget via custom code

### DIFF
--- a/.changeset/nervous-seahorses-allow.md
+++ b/.changeset/nervous-seahorses-allow.md
@@ -1,0 +1,5 @@
+---
+"wptelegram-widget": patch
+---
+
+Added multi-group support for legacy widget via custom code

--- a/plugins/wptelegram-widget/js/blocks/single-post/index.tsx
+++ b/plugins/wptelegram-widget/js/blocks/single-post/index.tsx
@@ -27,7 +27,6 @@ registerBlockType('wptelegram/widget-single-post', {
 		return (
 			<div
 				className={`wp-block-wptelegram-widget-single-post wptelegram-widget-message align${alignment}`}
-				// {...useBlockProps.save()}
 			>
 				<iframe title={__('Telegram post')} src={iframe_src}>
 					Your Browser Does Not Support iframes!

--- a/plugins/wptelegram-widget/src/admin/Admin.php
+++ b/plugins/wptelegram-widget/src/admin/Admin.php
@@ -245,10 +245,10 @@ class Admin extends BaseClass {
 
 		foreach ( (array) $updates as $update ) {
 
-			$message_id = $this->process_update( $update );
+			list($message_id, $username) = $this->process_update( $update );
 
 			if ( $message_id ) {
-				$new_messages[] = $message_id;
+				$new_messages[ $username ][] = $message_id;
 			}
 		}
 
@@ -257,9 +257,11 @@ class Admin extends BaseClass {
 		$this->plugin()->options()->set( 'last_update_id', $update_id );
 
 		if ( ! empty( $new_messages ) ) {
-			$username = $this->plugin()->options()->get_path( 'legacy_widget.username', '' );
-
-			$this->save_messages( $new_messages, $username );
+			foreach ( $new_messages as $username => $messages ) {
+				if ( ! empty( $messages ) ) {
+					$this->save_messages( $messages, $username );
+				}
+			}
 		}
 
 		/**
@@ -273,6 +275,8 @@ class Admin extends BaseClass {
 	 *
 	 * @param array $update    Update object.
 	 *
+	 * @return array|bool
+	 *
 	 * @since    1.3.0
 	 */
 	private function process_update( $update ) {
@@ -285,23 +289,23 @@ class Admin extends BaseClass {
 		$update_type = $this->get_update_type( $update );
 
 		if ( ! $update_type ) {
-			return false;
+			return [ 0, '' ];
 		}
 
 		$message = $update[ $update_type ];
 
-		$verified = $this->verify_username( $message );
+		$username = $this->get_verified_username( $message );
 
-		if ( ! $verified ) {
-			return false;
+		if ( ! $username ) {
+			return [ 0, '' ];
 		}
 
 		/**
 		 * Fires after doing everything
 		 */
-		do_action( 'wptelegram_widget_process_update_finish', $update, $message, $verified );
+		do_action( 'wptelegram_widget_process_update_finish', $update, $message, $username );
 
-		return $message['message_id'];
+		return [ $message['message_id'], $username ];
 	}
 
 	/**
@@ -326,6 +330,22 @@ class Admin extends BaseClass {
 		}
 
 		return apply_filters( 'wptelegram_widget_update_type', $update_type, $update );
+	}
+
+	/**
+	 * Get the verified username.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array $message The message object.
+	 *
+	 * @return string
+	 */
+	public function get_verified_username( $message ) {
+
+		$verified_username = $this->verify_username( $message ) ? $message['chat']['username'] : '';
+
+		return apply_filters( 'wptelegram_widget_verified_username', $verified_username, $message );
 	}
 
 	/**
@@ -415,19 +435,14 @@ class Admin extends BaseClass {
 
 		$result = $res->get_result();
 
-		if ( empty( $result['chat']['username'] ) ) {
-			return;
-		}
+		$verified_username = $this->get_verified_username( $result );
 
-		$used_username  = strtolower( $result['chat']['username'] );
-		$saved_username = strtolower( $this->plugin()->options()->get_path( 'legacy_widget.username' ) );
-
-		if ( $used_username !== $saved_username ) {
+		if ( ! $verified_username ) {
 			return;
 		}
 
 		$messages = [ $result['message_id'] ];
 
-		$this->save_messages( $messages, $saved_username );
+		$this->save_messages( $messages, $verified_username );
 	}
 }

--- a/plugins/wptelegram-widget/src/shared/shortcodes/LegacyWidget.php
+++ b/plugins/wptelegram-widget/src/shared/shortcodes/LegacyWidget.php
@@ -35,18 +35,13 @@ class LegacyWidget {
 			$atts['width'] = $atts['widget_width'];
 		}
 
-		// fetch messages.
-		$messages = WPTG_Widget()->options()->get( 'messages', [] );
 		$username = strtolower( WPTG_Widget()->options()->get_path( 'legacy_widget.username', '' ) );
-
-		if ( empty( $messages[ $username ] ) ) {
-			return;
-		}
 
 		$defaults = [
 			'num_messages' => 5,
 			'width'        => 100,
 			'author_photo' => 'auto',
+			'username'     => $username,
 		];
 
 		// use global options.
@@ -57,6 +52,15 @@ class LegacyWidget {
 		$args = shortcode_atts( $defaults, $atts, 'wptelegram-widget' );
 
 		$args = array_map( 'sanitize_text_field', $args );
+
+		// Get messages.
+		$messages = WPTG_Widget()->options()->get( 'messages', [] );
+
+		$username = $args['username'];
+
+		if ( empty( $messages[ $username ] ) ) {
+			return;
+		}
 
 		$num_messages = absint( $args['num_messages'] );
 
@@ -107,14 +111,14 @@ class LegacyWidget {
 			 * if either the child theme or the parent theme have overridden the template.
 			 */
 			if ( Utils::is_valid_template( $overridden_template ) ) {
-				load_template( $overridden_template );
+				load_template( $overridden_template, false );
 			}
 		} else {
 			/*
 			 * If neither the child nor parent theme have overridden the template,
 			 * we load the template from the 'partials' sub-directory of the directory this file is in.
 			 */
-			load_template( __DIR__ . '/../partials/legacy-widget.php' );
+			load_template( __DIR__ . '/../partials/legacy-widget.php', false );
 		}
 		$html = ob_get_clean();
 		return $html;


### PR DESCRIPTION
This PR adds support for multi group support for WP Telegram Widget (Legacy widget) via custom code.

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->


## Usage

You can now use the below custom code to ensure the allowed usernames are treated as verified ones


```php
// WP Telegram Widget | Handle multiple groups.
add_filter( 'wptelegram_widget_verify_username', function ( $verified, $message ) {
	$allowed_groups = [
		// Add your group usernames here.
		'WPTelegramChat',
		'WPTelegramChatRU',
	];

	$allowed_groups = array_map( 'strtolower', $allowed_groups );

	if ( ! $verified ) {
		if ( ! empty( $message['chat']['username'] ) ) {
			$username = $message['chat']['username'];

			if ( in_array( strtolower( $username ), $allowed_groups, true ) ) {
				$verified = true;
			}
		}
	}

	return $verified;
}, 10, 2 );
```

Once you do that, you can pass the username via the shortcode

```
[wptelegram-widget num_messages="10" username="WPTelegramChat"]
```