### PR TITLE
Add support for p2tg fields JSON output

### DIFF
--- a/.changeset/proud-badgers-push.md
+++ b/.changeset/proud-badgers-push.md
@@ -1,0 +1,5 @@
+---
+"wptelegram": patch
+---
+
+Add support for {cf:field-name:json} for custom fields

--- a/.changeset/quiet-parrots-obey.md
+++ b/.changeset/quiet-parrots-obey.md
@@ -1,0 +1,5 @@
+---
+"wptelegram": patch
+---
+
+Fix PHP warning for array to string conversion

--- a/plugins/wptelegram/js/p2tg-block-editor/OverrideSettings.tsx
+++ b/plugins/wptelegram/js/p2tg-block-editor/OverrideSettings.tsx
@@ -101,6 +101,7 @@ export const OverrideSettings: React.FC = () => {
 										min={0}
 										type="number"
 										__nextHasNoMarginBottom
+										__next40pxDefaultSize
 									/>
 									<ToggleControl
 										label={__('Featured Image')}

--- a/plugins/wptelegram/src/modules/p2tg/PostData.php
+++ b/plugins/wptelegram/src/modules/p2tg/PostData.php
@@ -305,6 +305,13 @@ class PostData {
 
 		$value = apply_filters( 'wptelegram_p2tg_post_data_field_value', $value, $field, $this->post, $options );
 
+		$value = apply_filters( "wptelegram_p2tg_post_data_{$field}_value", $value, $this->post, $options );
+
+		// If the value can't be converted to string.
+		if ( ! is_scalar( $value ) ) {
+			return '';
+		}
+
 		$remove_multi_eol = apply_filters( 'wptelegram_p2tg_post_data_remove_multi_eol', true, $this->post );
 
 		if ( $remove_multi_eol ) {
@@ -312,7 +319,8 @@ class PostData {
 			$value = preg_replace( '/\n[\n\r\s]*\n[\n\r\s]*\n/u', "\n\n", $value );
 		}
 
-		return (string) apply_filters( "wptelegram_p2tg_post_data_{$field}_value", $value, $this->post, $options );
+		// If the value can be converted to string.
+		return (string) $value;
 	}
 
 	/**

--- a/plugins/wptelegram/src/modules/p2tg/PostData.php
+++ b/plugins/wptelegram/src/modules/p2tg/PostData.php
@@ -102,6 +102,8 @@ class PostData {
 
 		$value = '';
 
+		$json_encode = 0;
+
 		switch ( $field ) {
 
 			case 'id':
@@ -265,6 +267,9 @@ class PostData {
 
 					$_field = preg_replace( '/^' . $match[1] . ':/i', '', $field );
 
+					// If the field name ends with :json, $json_encode will become 1.
+					$_field = preg_replace( '/:json$/i', '', $_field, 1, $json_encode );
+
 					switch ( $match[1] ) {
 
 						case 'terms': // if taxonomy.
@@ -303,6 +308,10 @@ class PostData {
 				break;
 		}
 
+		if ( $json_encode ) {
+			$value = wp_json_encode( $value );
+		}
+
 		$value = apply_filters( 'wptelegram_p2tg_post_data_field_value', $value, $field, $this->post, $options );
 
 		$value = apply_filters( "wptelegram_p2tg_post_data_{$field}_value", $value, $this->post, $options );
@@ -314,7 +323,7 @@ class PostData {
 
 		$remove_multi_eol = apply_filters( 'wptelegram_p2tg_post_data_remove_multi_eol', true, $this->post );
 
-		if ( $remove_multi_eol ) {
+		if ( $remove_multi_eol && ! $json_encode ) {
 			// remove multiple newlines.
 			$value = preg_replace( '/\n[\n\r\s]*\n[\n\r\s]*\n/u', "\n\n", $value );
 		}

--- a/plugins/wptelegram/src/modules/p2tg/TemplateParser.php
+++ b/plugins/wptelegram/src/modules/p2tg/TemplateParser.php
@@ -245,7 +245,7 @@ class TemplateParser {
 		}
 
 		// if it's something unusual :) .
-		if ( preg_match_all( '/(?<=\{)(terms|a?cf):([^\}]+?)(?=\})/iu', $template, $matches ) ) {
+		if ( preg_match_all( '/(?<=\{)(terms|cf):([^\}]+?)(?=\})/iu', $template, $matches ) ) {
 
 			foreach ( $matches[0] as $field ) {
 				$key = '{' . $field . '}';


### PR DESCRIPTION
Users can now use `{cf:field-name:json}` to debug the complex custom field values

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
