### PR TITLE
Fix warnings for TextControl and SelectControl for WP 6.8

### DIFF
--- a/.changeset/proud-knives-lick.md
+++ b/.changeset/proud-knives-lick.md
@@ -1,0 +1,6 @@
+---
+"wptelegram-widget": patch
+"wptelegram-login": patch
+---
+
+Fix warnings for TextControl and SelectControl for WP 6.8

--- a/plugins/wptelegram-login/js/blocks/telegram-login/Edit.tsx
+++ b/plugins/wptelegram-login/js/blocks/telegram-login/Edit.tsx
@@ -97,6 +97,7 @@ export const Edit: React.FC<BlockEditProps<TelegramLoginAtts>> = ({
 							min="0"
 							max="20"
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 						<SelectControl
 							label={__('Language')}
@@ -104,6 +105,7 @@ export const Edit: React.FC<BlockEditProps<TelegramLoginAtts>> = ({
 							onChange={onChangeLang}
 							options={uiData.lang}
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 						<SelectControl
 							label={__('Show if user is')}
@@ -111,6 +113,7 @@ export const Edit: React.FC<BlockEditProps<TelegramLoginAtts>> = ({
 							onChange={onChangeShowIfUserIs}
 							options={uiData.show_if_user_is}
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 					</Flex>
 				</PanelBody>

--- a/plugins/wptelegram-widget/js/blocks/ajax-channel-feed/Edit.tsx
+++ b/plugins/wptelegram-widget/js/blocks/ajax-channel-feed/Edit.tsx
@@ -47,6 +47,7 @@ export const Edit: React.FC<BlockEditProps<AjaxWidgetAtts>> = ({
 							)}
 							placeholder={savedSettings?.username || 'WPTelegram'}
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 						<TextControl
 							label={__('Widget Width')}
@@ -54,6 +55,7 @@ export const Edit: React.FC<BlockEditProps<AjaxWidgetAtts>> = ({
 							onChange={onChangeWidth}
 							placeholder={`300 ${__('or')} 100%`}
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 						<TextControl
 							label={__('Widget Height')}
@@ -61,6 +63,7 @@ export const Edit: React.FC<BlockEditProps<AjaxWidgetAtts>> = ({
 							onChange={onChangeHeight}
 							placeholder={`300 ${__('or')} 100%`}
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 					</Flex>
 				</PanelBody>

--- a/plugins/wptelegram-widget/js/blocks/channel-feed/Edit.tsx
+++ b/plugins/wptelegram-widget/js/blocks/channel-feed/Edit.tsx
@@ -59,6 +59,7 @@ export const Edit: React.FC<BlockEditProps<LegacyWidgetAtts>> = ({
 							onChange={onChangeWidth}
 							placeholder={`300 ${__('or')} 100%`}
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 						<RadioControl
 							label={__('Author Photo')}
@@ -74,6 +75,7 @@ export const Edit: React.FC<BlockEditProps<LegacyWidgetAtts>> = ({
 							min="1"
 							max="50"
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 					</Flex>
 				</PanelBody>

--- a/plugins/wptelegram-widget/js/blocks/join-channel/Controls.tsx
+++ b/plugins/wptelegram-widget/js/blocks/join-channel/Controls.tsx
@@ -58,12 +58,14 @@ export const Controls: React.FC<ControlsProps> = ({
 							onChange={onChangeChannelLink}
 							type="url"
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 						<TextControl
 							label={__('Button text')}
 							value={text || ''}
 							onChange={onChangeButtonText}
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 					</Flex>
 				</PanelBody>


### PR DESCRIPTION
<!--- Some description here -->

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
