### PR TITLE
WP Utils: ViteWPReactAssets: Fix PHP warning for undefined variable

### DIFF
--- a/.changeset/cold-cats-move.md
+++ b/.changeset/cold-cats-move.md
@@ -1,0 +1,5 @@
+---
+"@wpsocio/wp-utils": patch
+---
+
+Fixed PHP warning for undefined variable.

--- a/packages/php/wp-utils/src/ViteWPReactAssets.php
+++ b/packages/php/wp-utils/src/ViteWPReactAssets.php
@@ -584,7 +584,7 @@ class ViteWPReactAssets {
 		}
 
 		if ( ! empty( $options['inline-style'] ) ) {
-			$handle = $this->is_dev() && ! empty( $options['inline-style']['dev-dependency'] ) ? $options['inline-style']['dev-dependency'] : $style_handle;
+			$handle = $this->is_dev() && ! empty( $options['inline-style']['dev-dependency'] ) ? $options['inline-style']['dev-dependency'] : $style_handle ?? '';
 
 			$data = $options['inline-style']['data'];
 


### PR DESCRIPTION
<!--- Some description here -->

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
