### PR TITLE
WP Telegram Login: Delay request intercept

### DIFF
--- a/.changeset/smart-wasps-attack.md
+++ b/.changeset/smart-wasps-attack.md
@@ -1,0 +1,5 @@
+---
+"wptelegram-login": patch
+---
+
+Delay request intercept on init from 5 to 12

--- a/plugins/wptelegram-login/src/includes/Main.php
+++ b/plugins/wptelegram-login/src/includes/Main.php
@@ -388,7 +388,7 @@ class Main {
 
 		$login_handler = LoginHandler::instance();
 
-		$hook_and_priority = [ 'init', 5 ];
+		$hook_and_priority = [ 'init', 20 ];
 		/**
 		 * Filter the hook and priority to use for intercepting the login request.
 		 *


### PR DESCRIPTION
In #85, we replace `init` with `parse_query` for catching the login request but we had to revert it in #97. It seems like #85 had done it wrongly thinking that `parse_query` gets fired after init. So, we are changing it to `init` but with higher priority - `20` to wait for plugins/themes to finish CPT registration.

See https://wordpress.org/support/topic/making-site-critical-error/

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
