### PR TITLE
Use wp_loaded hook to intercept login requests

### DIFF
--- a/plugins/wptelegram-login/src/includes/Main.php
+++ b/plugins/wptelegram-login/src/includes/Main.php
@@ -388,17 +388,9 @@ class Main {
 
 		$login_handler = LoginHandler::instance();
 
-		$hook_and_priority = [ 'init', 20 ];
-		/**
-		 * Filter the hook and priority to use for intercepting the login request.
-		 *
-		 * - [Examples](./examples/intercept_request_on.md)
-		 *
-		 * @param array $hook_and_priority The hook and priority.
-		 */
-		list( $login_intercept_hook, $priority ) = apply_filters( 'wptelegram_login_intercept_request_on', $hook_and_priority );
+		$login_intercept = Utils::get_intercept_details();
 
-		add_action( $login_intercept_hook, [ $login_handler, 'telegram_login' ], $priority );
+		add_action( $login_intercept['hook'], [ $login_handler, 'telegram_login' ], $login_intercept['priority'] );
 
 		$asset_manager = $this->asset_manager();
 

--- a/plugins/wptelegram-login/src/includes/Utils.php
+++ b/plugins/wptelegram-login/src/includes/Utils.php
@@ -116,4 +116,30 @@ class Utils extends \WPSocio\WPUtils\Helpers {
 		 */
 		return apply_filters( 'wptelegram_login_get_user_by_telegram_id', $user, $tg_user_id );
 	}
+
+	/**
+	 * Get the hook details to use for intercepting the login.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return array Hook and priority.
+	 */
+	public static function get_intercept_details() {
+
+		$hook_and_priority = [ 'wp_loaded', 20 ];
+
+		/**
+		 * Filter the hook and priority to use for intercepting the login request.
+		 *
+		 * - [Examples](./examples/intercept_request_on.md)
+		 *
+		 * @param array $hook_and_priority A tuple containing the hook name and priority.
+		 */
+		$details = apply_filters( 'wptelegram_login_intercept_request_on', $hook_and_priority );
+
+		return [
+			'hook'     => is_string( $details[0] ?? null ) ? $details[0] : $hook_and_priority[0],
+			'priority' => is_int( $details[1] ?? null ) ? $details[1] : $hook_and_priority[1],
+		];
+	}
 }

--- a/plugins/wptelegram-login/src/shared/LoginHandler.php
+++ b/plugins/wptelegram-login/src/shared/LoginHandler.php
@@ -157,7 +157,7 @@ class LoginHandler extends BaseClass {
 	}
 
 	/**
-	 * Check if the Telegram Login request is valid
+	 * Check if the request is for a valid Telegram Login
 	 *
 	 * @since    1.0.0
 	 *


### PR DESCRIPTION
Following #250, it's better to further delay intercepting the request until `wp_loaded` to ensure all the plugins and themes are properly loaded before intercepting the request.

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
