### PR TITLE
Disable wireit caching

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -53,9 +53,9 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
 
-    - name: Wireit cache
-      if: ${{ inputs.enable-wireit-cache == 'true' }}
-      uses: google/wireit@setup-github-actions-caching/v2
+    # - name: Wireit cache
+    #   if: ${{ inputs.enable-wireit-cache == 'true' }}
+    #   uses: google/wireit@setup-github-actions-caching/v2
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
Wireit uses outdated caching for GitHub actions. See https://github.com/google/wireit/issues/1297

We are disabling it until it's fixed.

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
