### PR TITLE
Fix Bot Token and Message tests not working for lowercase URLs

### DIFF
--- a/.changeset/fast-rooms-wave.md
+++ b/.changeset/fast-rooms-wave.md
@@ -1,0 +1,5 @@
+---
+"@wpsocio/wptelegram-bot-api": patch
+---
+
+Change the route param to api_method to allow passing via query param

--- a/.changeset/light-snails-walk.md
+++ b/.changeset/light-snails-walk.md
@@ -1,0 +1,7 @@
+---
+"wptelegram": patch
+"wptelegram-login": patch
+"wptelegram-widget": patch
+---
+
+Fixed Bot Token and Message tests not working for lowercase URLs

--- a/packages/js/services/telegram/telegram-api.ts
+++ b/packages/js/services/telegram/telegram-api.ts
@@ -75,7 +75,7 @@ class ApiClient implements TelegramApi {
 					api_params: apiParams,
 				},
 				// use WP REST relative path
-				path: `${this.path}/${apiMethod}/`,
+				path: `${this.path}/base?api_method=${apiMethod}`,
 			};
 		}
 

--- a/packages/php/wptelegram-bot-api/src/restApi/RESTAPIController.php
+++ b/packages/php/wptelegram-bot-api/src/restApi/RESTAPIController.php
@@ -31,7 +31,7 @@ class RESTAPIController extends RESTBaseController {
 	 *
 	 * @var string
 	 */
-	const REST_BASE = '/(?P<method>[a-zA-Z]+)';
+	const REST_BASE = '/(?P<api_method>[a-zA-Z]+)';
 
 	/**
 	 * Whether the dependencies have been initiated.
@@ -106,7 +106,7 @@ class RESTAPIController extends RESTBaseController {
 	public function handle_request( WP_REST_Request $request ) {
 
 		$bot_token  = $request->get_param( 'bot_token' );
-		$api_method = $request->get_param( 'method' );
+		$api_method = $request->get_param( 'api_method' );
 		$api_params = $request->get_param( 'api_params' );
 
 		$body = [];

--- a/test/e2e/specs/wptelegram-login/settings-page.spec.ts
+++ b/test/e2e/specs/wptelegram-login/settings-page.spec.ts
@@ -99,6 +99,7 @@ test.describe('Settings', () => {
 
 		await actions.testBotTokenAndWait({
 			endpoint: `/bot${TEST_BOT_TOKEN}/getMe`,
+			query: {},
 		});
 
 		await resultAlert.waitFor();
@@ -133,6 +134,7 @@ test.describe('Settings', () => {
 
 		await actions.testBotTokenAndWait({
 			endpoint: `/bot${TEST_BOT_TOKEN}/getMe`,
+			query: {},
 		});
 
 		await resultAlert.waitFor();

--- a/test/e2e/specs/wptelegram/settings-page.spec.ts
+++ b/test/e2e/specs/wptelegram/settings-page.spec.ts
@@ -106,7 +106,9 @@ test.describe('Settings', () => {
 			},
 		};
 		// Mock the api call
-		await mocks.mockRequest('/wptelegram-bot/v1/getMe', { json });
+		const unmock = await mocks.mockRequest('/wptelegram-bot/v1/base', {
+			json,
+		});
 
 		const botTokenField = page.getByLabel('Bot Token');
 		const botUsernameField = page.getByLabel('Bot Username');
@@ -130,13 +132,15 @@ test.describe('Settings', () => {
 		await expect(resultAlert).toContainText(result);
 
 		await expect(botUsernameField).toHaveValue(json.result.username);
+
+		await unmock();
 	});
 
 	test('Should handle the API call for invalid token', async ({ page }) => {
 		const json = { ok: false, error_code: 401, description: 'Unauthorized' };
 
 		// Mock the api call
-		const unmock = await mocks.mockRequest('/wptelegram-bot/v1/getMe', {
+		const unmock = await mocks.mockRequest('/wptelegram-bot/v1/base', {
 			json,
 			status: json.error_code,
 		});

--- a/tools/e2e-utils/src/actions.ts
+++ b/tools/e2e-utils/src/actions.ts
@@ -68,8 +68,9 @@ export class Actions {
 	}
 
 	async testBotTokenAndWait({
-		endpoint = '/wptelegram-bot/v1/getMe',
-	}: { endpoint?: string } = {}) {
+		endpoint = '/wptelegram-bot/v1/base',
+		query = { api_method: 'getMe' },
+	}: { endpoint?: string; query?: Record<string, string> } = {}) {
 		const testButton = this.page.getByRole('button', {
 			name: 'Test Token',
 			exact: true,
@@ -77,7 +78,7 @@ export class Actions {
 
 		return await Promise.all([
 			testButton.click(),
-			this.waitForApiResponse(endpoint),
+			this.waitForApiResponse(endpoint, query),
 		]);
 	}
 


### PR DESCRIPTION
Related to the issue here https://wordpress.org/support/topic/rest_missing_callback_param-3/

If the site/server is configured to use lowercase URL paths, then the Bot Token Test and Test Messages fail because of the usage of camelcase methods like `getMe`, `sendMessage`.

This PR updates the Bot API library to accept the `api_method` via the URL query params.

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
