### PR TITLE
Update notices to show specific errors first

### DIFF
--- a/.changeset/bitter-carrots-grow.md
+++ b/.changeset/bitter-carrots-grow.md
@@ -1,0 +1,8 @@
+---
+"wptelegram": patch
+"wptelegram-comments": patch
+"wptelegram-login": patch
+"wptelegram-widget": patch
+---
+
+Updated error notices to show specific errors first.

--- a/packages/js/services/use-display-feedback.ts
+++ b/packages/js/services/use-display-feedback.ts
@@ -59,8 +59,8 @@ export const useDisplayFeedback = (): DF => {
 		(errors, error) => {
 			const title =
 				typeof error === 'string' ? error : __('Lets fix these errors first.');
-			displayErrors(errors);
 			displayError({ title });
+			displayErrors(errors);
 		},
 		[displayError, displayErrors],
 	);


### PR DESCRIPTION
The error notices are stacked with "Lets fix these errors first." being the only visible one until you click on it. So, it's better to show specific errors first.

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
