### PR TITLE
Fix Legacy Widget expecting a lowercase username.

### DIFF
--- a/.changeset/ten-rivers-lie.md
+++ b/.changeset/ten-rivers-lie.md
@@ -1,0 +1,5 @@
+---
+"wptelegram-widget": patch
+---
+
+Fixed Legacy Widget expecting a lowercase username.

--- a/plugins/wptelegram-widget/src/shared/shortcodes/LegacyWidget.php
+++ b/plugins/wptelegram-widget/src/shared/shortcodes/LegacyWidget.php
@@ -35,7 +35,7 @@ class LegacyWidget {
 			$atts['width'] = $atts['widget_width'];
 		}
 
-		$username = strtolower( WPTG_Widget()->options()->get_path( 'legacy_widget.username', '' ) );
+		$username = WPTG_Widget()->options()->get_path( 'legacy_widget.username', '' );
 
 		$defaults = [
 			'num_messages' => 5,
@@ -56,7 +56,7 @@ class LegacyWidget {
 		// Get messages.
 		$messages = WPTG_Widget()->options()->get( 'messages', [] );
 
-		$username = $args['username'];
+		$username = strtolower( $args['username'] );
 
 		if ( empty( $messages[ $username ] ) ) {
 			return;


### PR DESCRIPTION
We had a [user reporting](https://wordpress.org/support/topic/problem-legacy-widget-simply-no-output-at-all/) that they saw an empty output for the Legacy widget. It turned out to be a bug in the plugin where the username is expected to be lowercase.

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
