### PR TITLE
vite-wp-react: Use relative path for emitted assets

### DIFF
--- a/.changeset/whole-islands-teach.md
+++ b/.changeset/whole-islands-teach.md
@@ -1,0 +1,5 @@
+---
+"@wpsocio/vite-wp-react": patch
+---
+
+Updated the base path to use relative paths for emitted assets

--- a/tools/vite-wp-react/src/config.ts
+++ b/tools/vite-wp-react/src/config.ts
@@ -18,6 +18,8 @@ export function createViteConfig({
 	corsOrigin,
 }: CreateViteConfigOptions): UserConfig {
 	return {
+		// Ensure that the asset paths are relative.
+		base: './',
 		plugins: [
 			viteWpReact(
 				{ outDir, input, assetsDir: 'dist' },


### PR DESCRIPTION
<!--- Some description here -->

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
