### PR TITLE
Add Telegram Rich Message foundations

### DIFF
--- a/.changeset/rich-html-converter.md
+++ b/.changeset/rich-html-converter.md
@@ -1,0 +1,5 @@
+---
+"@wpsocio/telegram-format-text": minor
+---
+
+Add `RichHtmlConverter` to normalize and trim Telegram Rich HTML.

--- a/packages/js/shared-ui/wptelegram/image-settings.tsx
+++ b/packages/js/shared-ui/wptelegram/image-settings.tsx
@@ -13,11 +13,13 @@ import type { CommonProps } from './types.js';
 
 export type ImageSettingsProps = CommonProps & {
 	disabled?: boolean;
+	disabledReason?: React.ReactNode;
 };
 
 export const ImageSettings: React.FC<ImageSettingsProps> = ({
 	prefix,
 	disabled = false,
+	disabledReason,
 }) => {
 	const sendFeaturedImage = useWatch({
 		name: prefixName('send_featured_image', prefix),
@@ -48,7 +50,16 @@ export const ImageSettings: React.FC<ImageSettingsProps> = ({
 						<FormItem
 							className="md:flex-col"
 							label={getFieldLabel('send_featured_image')}
-							description={__('Send Featured Image (if exists).')}
+							description={
+								<>
+									{__('Send Featured Image (if exists).')}
+									{disabled && disabledReason ? (
+										<span className="block text-destructive">
+											{disabledReason}
+										</span>
+									) : null}
+								</>
+							}
 							isDisabled={disabled}
 						>
 							<FormControl>

--- a/packages/js/shared-ui/wptelegram/image-settings.tsx
+++ b/packages/js/shared-ui/wptelegram/image-settings.tsx
@@ -11,25 +11,33 @@ import { getFieldLabel } from './fields.js';
 import { SingleMessage } from './single-message.js';
 import type { CommonProps } from './types.js';
 
-export const ImageSettings: React.FC<CommonProps> = ({ prefix }) => {
-	const isDisabled = !useWatch({
+export type ImageSettingsProps = CommonProps & {
+	disabled?: boolean;
+};
+
+export const ImageSettings: React.FC<ImageSettingsProps> = ({
+	prefix,
+	disabled = false,
+}) => {
+	const sendFeaturedImage = useWatch({
 		name: prefixName('send_featured_image', prefix),
 	});
+	const areDependentFieldsDisabled = disabled || !sendFeaturedImage;
 
 	const image_position_options = useMemo(
 		() => [
 			{
 				value: 'before',
 				label: __('Before the Text'),
-				isDisabled,
+				isDisabled: areDependentFieldsDisabled,
 			},
 			{
 				value: 'after',
 				label: __('After the Text'),
-				isDisabled,
+				isDisabled: areDependentFieldsDisabled,
 			},
 		],
-		[isDisabled],
+		[areDependentFieldsDisabled],
 	);
 	return (
 		<div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-2 my-6">
@@ -41,6 +49,7 @@ export const ImageSettings: React.FC<CommonProps> = ({ prefix }) => {
 							className="md:flex-col"
 							label={getFieldLabel('send_featured_image')}
 							description={__('Send Featured Image (if exists).')}
+							isDisabled={disabled}
 						>
 							<FormControl>
 								<Switch
@@ -48,6 +57,8 @@ export const ImageSettings: React.FC<CommonProps> = ({ prefix }) => {
 									value={undefined}
 									checked={field.value}
 									onCheckedChange={field.onChange}
+									disabled={disabled}
+									aria-readonly={disabled}
 								/>
 							</FormControl>
 						</FormItem>
@@ -61,7 +72,7 @@ export const ImageSettings: React.FC<CommonProps> = ({ prefix }) => {
 						<FormItem
 							label={getFieldLabel('image_position')}
 							className="md:flex-col"
-							isDisabled={isDisabled}
+							isDisabled={areDependentFieldsDisabled}
 						>
 							<FormControl>
 								<RadioGroup
@@ -69,7 +80,7 @@ export const ImageSettings: React.FC<CommonProps> = ({ prefix }) => {
 									onValueChange={field.onChange}
 									defaultValue={field.value}
 									options={image_position_options}
-									disabled={isDisabled}
+									disabled={areDependentFieldsDisabled}
 								/>
 							</FormControl>
 						</FormItem>
@@ -77,7 +88,7 @@ export const ImageSettings: React.FC<CommonProps> = ({ prefix }) => {
 				/>
 			</div>
 			<div>
-				<SingleMessage prefix={prefix} disabled={isDisabled} />
+				<SingleMessage prefix={prefix} disabled={areDependentFieldsDisabled} />
 			</div>
 		</div>
 	);

--- a/packages/js/shared-ui/wptelegram/link-preview-options.tsx
+++ b/packages/js/shared-ui/wptelegram/link-preview-options.tsx
@@ -11,10 +11,20 @@ import { FormItem } from '../form/form-item.js';
 import { getFieldLabel } from './fields.js';
 import type { CommonProps } from './types.js';
 
-export const LinkPreviewOptions: React.FC<CommonProps> = ({ prefix }) => {
+export type LinkPreviewOptionsProps = CommonProps & {
+	disabled?: boolean;
+	disabledReason?: React.ReactNode;
+};
+
+export const LinkPreviewOptions: React.FC<LinkPreviewOptionsProps> = ({
+	prefix,
+	disabled = false,
+	disabledReason,
+}) => {
 	const link_preview_disabled = useWatch({
 		name: prefixName('link_preview_disabled', prefix),
 	});
+	const areDependentFieldsDisabled = disabled || link_preview_disabled;
 
 	return (
 		<div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-2 my-6">
@@ -25,7 +35,17 @@ export const LinkPreviewOptions: React.FC<CommonProps> = ({ prefix }) => {
 						<FormItem
 							className="md:flex-col"
 							label={getFieldLabel('link_preview_disabled')}
-							description={__('Disables previews for links in the messages.')}
+							description={
+								<>
+									{__('Disables previews for links in the messages.')}
+									{disabled && disabledReason ? (
+										<span className="block text-destructive">
+											{disabledReason}
+										</span>
+									) : null}
+								</>
+							}
+							isDisabled={disabled}
 						>
 							<FormControl>
 								<Switch
@@ -33,6 +53,8 @@ export const LinkPreviewOptions: React.FC<CommonProps> = ({ prefix }) => {
 									value={undefined}
 									checked={field.value}
 									onCheckedChange={field.onChange}
+									disabled={disabled}
+									aria-readonly={disabled}
 								/>
 							</FormControl>
 						</FormItem>
@@ -64,12 +86,12 @@ export const LinkPreviewOptions: React.FC<CommonProps> = ({ prefix }) => {
 									</span>
 								</>
 							}
-							isDisabled={link_preview_disabled}
+							isDisabled={areDependentFieldsDisabled}
 						>
 							<FormControl className="max-w-[200px]">
 								<Input
 									autoComplete="off"
-									disabled={link_preview_disabled}
+									disabled={areDependentFieldsDisabled}
 									placeholder="{full_url}"
 									{...field}
 								/>
@@ -88,7 +110,7 @@ export const LinkPreviewOptions: React.FC<CommonProps> = ({ prefix }) => {
 							description={__(
 								'Whether the link preview must be shown above the message text.',
 							)}
-							isDisabled={link_preview_disabled}
+							isDisabled={areDependentFieldsDisabled}
 						>
 							<FormControl>
 								<Switch
@@ -96,8 +118,8 @@ export const LinkPreviewOptions: React.FC<CommonProps> = ({ prefix }) => {
 									value={undefined}
 									checked={field.value}
 									onCheckedChange={field.onChange}
-									disabled={link_preview_disabled}
-									aria-readonly={link_preview_disabled}
+									disabled={areDependentFieldsDisabled}
+									aria-readonly={areDependentFieldsDisabled}
 								/>
 							</FormControl>
 						</FormItem>

--- a/packages/js/shared-ui/wptelegram/message-template.tsx
+++ b/packages/js/shared-ui/wptelegram/message-template.tsx
@@ -7,9 +7,14 @@ import { FormItem } from '../form/form-item.js';
 import { getFieldLabel } from './fields.js';
 import type { CommonProps } from './types.js';
 
-export type MessageTemplateProps = CommonProps;
+export type MessageTemplateProps = CommonProps & {
+	placeholder?: string;
+};
 
-export const MessageTemplate: React.FC<MessageTemplateProps> = ({ prefix }) => {
+export const MessageTemplate: React.FC<MessageTemplateProps> = ({
+	prefix,
+	placeholder,
+}) => {
 	return (
 		<FormField
 			name={prefixName('message_template', prefix)}
@@ -21,6 +26,7 @@ export const MessageTemplate: React.FC<MessageTemplateProps> = ({ prefix }) => {
 				>
 					<FormControl>
 						<Textarea
+							placeholder={placeholder}
 							rows={10}
 							spellCheck={false}
 							className="h-auto"

--- a/packages/js/shared-ui/wptelegram/misc-message-settings.tsx
+++ b/packages/js/shared-ui/wptelegram/misc-message-settings.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wpsocio/i18n';
 import { FormControl } from '@wpsocio/ui/components/form';
 import { Link } from '@wpsocio/ui/wrappers/link';
 import { Switch } from '@wpsocio/ui/wrappers/switch';
+import type { OptionsType } from '@wpsocio/ui/wrappers/types';
 import { prefixName } from '@wpsocio/utilities/misc.js';
 import { FormField } from '../form/form-field.js';
 import { FormItem } from '../form/form-item.js';
@@ -9,7 +10,16 @@ import { getFieldLabel } from './fields.js';
 import { ParseModeField } from './parse-mode-field.js';
 import type { CommonProps } from './types.js';
 
-export const MiscMessageSettings: React.FC<CommonProps> = ({ prefix }) => {
+export type MiscMessageSettingsProps = CommonProps & {
+	parseModeDocsLink?: string;
+	parseModeOptions?: OptionsType;
+};
+
+export const MiscMessageSettings: React.FC<MiscMessageSettingsProps> = ({
+	prefix,
+	parseModeDocsLink,
+	parseModeOptions,
+}) => {
 	return (
 		<div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-2 my-6">
 			<div>
@@ -34,7 +44,11 @@ export const MiscMessageSettings: React.FC<CommonProps> = ({ prefix }) => {
 				/>
 			</div>
 			<div>
-				<ParseModeField prefix={prefix} />
+				<ParseModeField
+					prefix={prefix}
+					docsLink={parseModeDocsLink}
+					options={parseModeOptions}
+				/>
 			</div>
 			<div>
 				<FormField

--- a/packages/js/shared-ui/wptelegram/parse-mode-field.tsx
+++ b/packages/js/shared-ui/wptelegram/parse-mode-field.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wpsocio/i18n';
 import { FormControl } from '@wpsocio/ui/components/form';
 import { Link } from '@wpsocio/ui/wrappers/link';
 import { RadioGroup } from '@wpsocio/ui/wrappers/radio-group';
+import type { OptionsType } from '@wpsocio/ui/wrappers/types';
 import { prefixName } from '@wpsocio/utilities/misc.js';
 import { FormField } from '../form/form-field.js';
 import { FormItem } from '../form/form-item.js';
@@ -10,6 +11,8 @@ import type { CommonProps } from './types.js';
 
 export type ParseModeFieldProps = CommonProps & {
 	asColumn?: boolean;
+	docsLink?: string;
+	options?: OptionsType;
 };
 
 export const getParseModeOptions = () => [
@@ -26,6 +29,8 @@ export const getParseModeOptions = () => [
 export const ParseModeField: React.FC<ParseModeFieldProps> = ({
 	prefix,
 	asColumn = true,
+	docsLink = 'https://core.telegram.org/bots/api#html-style',
+	options = getParseModeOptions(),
 }) => {
 	return (
 		<FormField
@@ -35,10 +40,7 @@ export const ParseModeField: React.FC<ParseModeFieldProps> = ({
 					className={asColumn ? 'md:flex-col' : ''}
 					label={getFieldLabel('parse_mode')}
 					description={
-						<Link
-							href="https://core.telegram.org/bots/api#html-style"
-							isExternal
-						>
+						<Link href={docsLink} isExternal>
 							{__('Learn more')}
 						</Link>
 					}
@@ -48,7 +50,7 @@ export const ParseModeField: React.FC<ParseModeFieldProps> = ({
 							{...field}
 							onValueChange={field.onChange}
 							defaultValue={field.value}
-							options={getParseModeOptions()}
+							options={options}
 						/>
 					</FormControl>
 				</FormItem>

--- a/packages/js/shared-ui/wptelegram/single-message.tsx
+++ b/packages/js/shared-ui/wptelegram/single-message.tsx
@@ -29,6 +29,7 @@ export const SingleMessage: React.FC<SingleMessageProps> = ({
 		});
 
 	const showWarning =
+		!disabled &&
 		single_message &&
 		image_position === 'after' &&
 		(parse_mode === 'none' || link_preview_disabled);

--- a/packages/php/telegram-format-text/src/RichHtmlConverter.php
+++ b/packages/php/telegram-format-text/src/RichHtmlConverter.php
@@ -248,16 +248,16 @@ class RichHtmlConverter implements HtmlConverterInterface {
 					$parent->removeChild( $child );
 				} elseif ( ! isset( self::ALLOWED_HTML[ $tag ] ) ) {
 					$this->sanitizeChildren( $child );
-					while ( $child->firstChild ) {
-						$parent->insertBefore( $child->firstChild, $child );
-					}
-					$parent->removeChild( $child );
+					$this->unwrapElement( $child );
 				} else {
 					$this->sanitizeAttributes( $child, $tag );
 					if ( in_array( $tag, [ 'audio', 'img', 'video' ], true ) && ! $child->hasAttribute( 'src' ) ) {
 						$parent->removeChild( $child );
 					} elseif ( 'input' === $tag && 'checkbox' !== $child->getAttribute( 'type' ) ) {
 						$parent->removeChild( $child );
+					} elseif ( $this->isIncompleteElement( $child, $tag ) ) {
+						$this->sanitizeChildren( $child );
+						$this->unwrapElement( $child );
 					} else {
 						$this->sanitizeChildren( $child );
 					}
@@ -268,6 +268,46 @@ class RichHtmlConverter implements HtmlConverterInterface {
 
 			$child = $next;
 		}
+	}
+
+	/**
+	 * Whether a semantic element is missing a required attribute.
+	 *
+	 * @param DOMElement $element Element to inspect.
+	 * @param string     $tag     Element tag.
+	 * @return bool
+	 */
+	private function isIncompleteElement( DOMElement $element, string $tag ) {
+		switch ( $tag ) {
+			case 'a':
+				return ! $element->hasAttribute( 'href' ) && ! $element->hasAttribute( 'name' );
+			case 'tg-emoji':
+				return ! $element->hasAttribute( 'emoji-id' );
+			case 'tg-reference':
+				return ! $element->hasAttribute( 'name' );
+			case 'tg-time':
+				return ! $element->hasAttribute( 'unix' );
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * Replace an element with its children.
+	 *
+	 * @param DOMElement $element Element to unwrap.
+	 * @return void
+	 */
+	private function unwrapElement( DOMElement $element ) {
+		$parent = $element->parentNode;
+		if ( ! $parent ) {
+			return;
+		}
+
+		while ( $element->firstChild ) {
+			$parent->insertBefore( $element->firstChild, $element );
+		}
+		$parent->removeChild( $element );
 	}
 
 	/**
@@ -314,6 +354,14 @@ class RichHtmlConverter implements HtmlConverterInterface {
 
 		if ( 'class' === $name ) {
 			return 'code' === $tag && (bool) preg_match( '/^language-[A-Za-z0-9_+-]+$/', $value );
+		}
+
+		if ( 'emoji-id' === $name ) {
+			return (bool) preg_match( '/^\d+$/', $value );
+		}
+
+		if ( 'name' === $name ) {
+			return '' !== trim( $value );
 		}
 
 		if ( in_array( $name, [ 'colspan', 'rowspan', 'start', 'unix', 'value', 'zoom' ], true ) ) {

--- a/packages/php/telegram-format-text/src/RichHtmlConverter.php
+++ b/packages/php/telegram-format-text/src/RichHtmlConverter.php
@@ -125,6 +125,20 @@ class RichHtmlConverter implements HtmlConverterInterface {
 	];
 
 	/**
+	 * Elements that never contain text of their own.
+	 *
+	 * @var string[]
+	 */
+	private const TEXTLESS_ELEMENTS = [ 'figure', 'ol', 'table', 'tg-collage', 'tg-slideshow', 'tr', 'ul' ];
+
+	/**
+	 * Elements that cannot hold child nodes.
+	 *
+	 * @var string[]
+	 */
+	private const VOID_ELEMENTS = [ 'audio', 'br', 'hr', 'img', 'input', 'tg-map', 'video' ];
+
+	/**
 	 * Ellipsis appended after truncated content.
 	 *
 	 * @var string
@@ -216,12 +230,13 @@ class RichHtmlConverter implements HtmlConverterInterface {
 		$document->strictErrorChecking = false;
 		$document->recover             = true;
 
-		libxml_use_internal_errors( true );
-		$loaded = $document->loadHTML(
+		$internal_errors = libxml_use_internal_errors( true );
+		$loaded          = $document->loadHTML(
 			'<?xml encoding="UTF-8"><div id="tg-rich-root">' . $html . '</div>',
 			LIBXML_NOWARNING | LIBXML_NOERROR | LIBXML_NONET | LIBXML_PARSEHUGE
 		);
 		libxml_clear_errors();
+		libxml_use_internal_errors( $internal_errors );
 
 		$root = $document->getElementById( 'tg-rich-root' );
 		if ( ! $loaded || ! $root ) {
@@ -513,9 +528,17 @@ class RichHtmlConverter implements HtmlConverterInterface {
 	 */
 	private function appendEllipsis( DOMElement $root, DOMDocument $document ) {
 		$target = $root;
-		while ( $target->lastChild instanceof DOMElement && ! in_array( strtolower( $target->lastChild->tagName ), [ 'br', 'hr', 'img', 'input', 'tg-map' ], true ) ) {
+
+		// Descend to the innermost trailing element that can hold children.
+		while ( $target->lastChild instanceof DOMElement && ! in_array( strtolower( $target->lastChild->tagName ), self::VOID_ELEMENTS, true ) ) {
 			$target = $target->lastChild;
 		}
+
+		// Climb back out of tables and lists, which accept only element children.
+		while ( $target !== $root && in_array( strtolower( $target->tagName ), self::TEXTLESS_ELEMENTS, true ) ) {
+			$target = $target->parentNode;
+		}
+
 		$target->appendChild( $document->createTextNode( $this->elipsis ) );
 	}
 

--- a/packages/php/telegram-format-text/src/RichHtmlConverter.php
+++ b/packages/php/telegram-format-text/src/RichHtmlConverter.php
@@ -212,7 +212,10 @@ class RichHtmlConverter implements HtmlConverterInterface {
 			return $converted;
 		}
 
-		$this->trimNode( $root, $limitBy, $limit );
+		// Keep room for the ellipsis so the result stays within the limit.
+		$remaining = max( 0, $limit - $this->getTextLength( $this->elipsis, $limitBy ) );
+
+		$this->trimNode( $root, $limitBy, $remaining );
 		$this->appendEllipsis( $root, $document );
 
 		return $this->serializeChildren( $root );
@@ -357,14 +360,17 @@ class RichHtmlConverter implements HtmlConverterInterface {
 	 */
 	private function isValidAttribute( string $tag, string $name, string $value ) {
 		if ( 'href' === $name ) {
-			return (bool) preg_match( '~^(?:https?://|mailto:|tel:|tg://user\?id=|#[A-Za-z0-9_.:-]+)~i', $value );
+			return (bool) preg_match(
+				'~^(?:https?://\S+|mailto:[^\s@]+@\S+|tel:\+?[\d\s().-]+|tg://user\?id=\d+|#[A-Za-z0-9_.:-]+)\z~iu',
+				$value
+			);
 		}
 
 		if ( 'src' === $name ) {
-			if ( 'img' === $tag && preg_match( '#^tg://emoji\?id=\d+$#', $value ) ) {
+			if ( 'img' === $tag && preg_match( '#^tg://emoji\?id=\d+\z#', $value ) ) {
 				return true;
 			}
-			return (bool) preg_match( '#^https?://#i', $value );
+			return (bool) preg_match( '#^https?://\S+\z#iu', $value );
 		}
 
 		if ( 'class' === $name ) {

--- a/packages/php/telegram-format-text/src/RichHtmlConverter.php
+++ b/packages/php/telegram-format-text/src/RichHtmlConverter.php
@@ -1,0 +1,487 @@
+<?php
+/**
+ * Converts HTML to Telegram Rich HTML.
+ *
+ * @package WPSocio\TelegramFormatText
+ */
+
+namespace WPSocio\TelegramFormatText;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMText;
+use WPSocio\TelegramFormatText\Exceptions\ConverterException;
+
+/**
+ * Converts and limits Telegram Rich HTML without changing its structure.
+ */
+class RichHtmlConverter implements HtmlConverterInterface {
+
+	/**
+	 * Telegram's maximum rich-message text length.
+	 */
+	const TG_RICH_TEXT_MAX_LENGTH = 32768;
+
+	/**
+	 * Telegram Rich HTML allowlist.
+	 *
+	 * @var array<string, array<string, bool>>
+	 */
+	private const ALLOWED_HTML = [
+		'a'             => [
+			'href' => true,
+			'name' => true,
+		],
+		'audio'         => [ 'src' => true ],
+		'aside'         => [],
+		'b'             => [],
+		'blockquote'    => [],
+		'br'            => [],
+		'caption'       => [],
+		'cite'          => [],
+		'code'          => [ 'class' => true ],
+		'del'           => [],
+		'details'       => [ 'open' => true ],
+		'em'            => [],
+		'figcaption'    => [],
+		'figure'        => [],
+		'footer'        => [],
+		'h1'            => [],
+		'h2'            => [],
+		'h3'            => [],
+		'h4'            => [],
+		'h5'            => [],
+		'h6'            => [],
+		'hr'            => [],
+		'i'             => [],
+		'img'           => [
+			'alt'        => true,
+			'src'        => true,
+			'tg-spoiler' => true,
+		],
+		'input'         => [
+			'checked' => true,
+			'type'    => true,
+		],
+		'ins'           => [],
+		'li'            => [
+			'type'  => true,
+			'value' => true,
+		],
+		'mark'          => [],
+		'ol'            => [
+			'reversed' => true,
+			'start'    => true,
+			'type'     => true,
+		],
+		'p'             => [],
+		'pre'           => [],
+		's'             => [],
+		'strike'        => [],
+		'strong'        => [],
+		'sub'           => [],
+		'summary'       => [],
+		'sup'           => [],
+		'table'         => [
+			'bordered' => true,
+			'striped'  => true,
+		],
+		'td'            => [
+			'align'   => true,
+			'colspan' => true,
+			'rowspan' => true,
+			'valign'  => true,
+		],
+		'tg-collage'    => [],
+		'tg-emoji'      => [ 'emoji-id' => true ],
+		'tg-map'        => [
+			'lat'  => true,
+			'long' => true,
+			'zoom' => true,
+		],
+		'tg-math'       => [],
+		'tg-math-block' => [],
+		'tg-reference'  => [ 'name' => true ],
+		'tg-slideshow'  => [],
+		'tg-spoiler'    => [],
+		'tg-time'       => [
+			'format' => true,
+			'unix'   => true,
+		],
+		'th'            => [
+			'align'   => true,
+			'colspan' => true,
+			'rowspan' => true,
+			'valign'  => true,
+		],
+		'tr'            => [],
+		'u'             => [],
+		'ul'            => [],
+		'video'         => [
+			'src'        => true,
+			'tg-spoiler' => true,
+		],
+	];
+
+	/**
+	 * Ellipsis appended after truncated content.
+	 *
+	 * @var string
+	 */
+	private $elipsis;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array<string, mixed> $options Converter options.
+	 */
+	public function __construct( $options = [] ) {
+		$this->elipsis = isset( $options['elipsis'] ) ? (string) $options['elipsis'] : '…';
+	}
+
+	/**
+	 * Return the canonical Telegram Rich HTML allowlist.
+	 *
+	 * @return array<string, array<string, bool>>
+	 */
+	public static function getAllowedHtml() {
+		return self::ALLOWED_HTML;
+	}
+
+	/**
+	 * Invoke the converter.
+	 *
+	 * @param string $html HTML to convert.
+	 * @return string
+	 */
+	public function __invoke( string $html ) {
+		return $this->convert( $html );
+	}
+
+	/**
+	 * Convert HTML to Telegram Rich HTML.
+	 *
+	 * @param string $html HTML to convert.
+	 * @return string
+	 */
+	public function convert( string $html ) {
+		if ( '' === trim( $html ) ) {
+			return '';
+		}
+
+		[ $document, $root ] = $this->createDocument( $html );
+		$this->sanitizeChildren( $root );
+
+		return $this->serializeChildren( $root );
+	}
+
+	/**
+	 * Safely limit Rich HTML without breaking its DOM structure.
+	 *
+	 * @param string $html    HTML to trim.
+	 * @param string $limitBy Either chars or words.
+	 * @param int    $limit   Maximum logical length.
+	 * @return string
+	 */
+	public function safeTrim( string $html, string $limitBy = 'chars', int $limit = self::TG_RICH_TEXT_MAX_LENGTH ) {
+		$converted = $this->convert( $html );
+
+		if ( '' === $converted || 0 >= $limit ) {
+			return 0 >= $limit && '' !== $converted ? $this->elipsis : $converted;
+		}
+
+		[ $document, $root ] = $this->createDocument( $converted );
+		$count               = $this->getLogicalLength( $root, $limitBy );
+
+		if ( $count <= $limit ) {
+			return $converted;
+		}
+
+		$this->trimNode( $root, $limitBy, $limit );
+		$this->appendEllipsis( $root, $document );
+
+		return $this->serializeChildren( $root );
+	}
+
+	/**
+	 * Create a wrapped DOM document.
+	 *
+	 * @param string $html HTML to parse.
+	 * @return array{DOMDocument, DOMElement}
+	 * @throws ConverterException When the HTML cannot be parsed.
+	 */
+	private function createDocument( string $html ) {
+		$document                      = new DOMDocument( '1.0', 'UTF-8' );
+		$document->strictErrorChecking = false;
+		$document->recover             = true;
+
+		libxml_use_internal_errors( true );
+		$loaded = $document->loadHTML(
+			'<?xml encoding="UTF-8"><div id="tg-rich-root">' . $html . '</div>',
+			LIBXML_NOWARNING | LIBXML_NOERROR | LIBXML_NONET | LIBXML_PARSEHUGE
+		);
+		libxml_clear_errors();
+
+		$root = $document->getElementById( 'tg-rich-root' );
+		if ( ! $loaded || ! $root ) {
+			throw new ConverterException( 'Unable to load Rich HTML.', 'load_rich_html_failed', $html );
+		}
+
+		return [ $document, $root ];
+	}
+
+	/**
+	 * Sanitize descendants in place.
+	 *
+	 * @param DOMNode $parent Parent node.
+	 * @return void
+	 */
+	private function sanitizeChildren( DOMNode $parent ) {
+		$child = $parent->firstChild;
+		while ( $child ) {
+			$next = $child->nextSibling;
+
+			if ( $child instanceof DOMElement ) {
+				$tag = strtolower( $child->tagName );
+				if ( in_array( $tag, [ 'form', 'iframe', 'object', 'script', 'style', 'tg-thinking' ], true ) ) {
+					$parent->removeChild( $child );
+				} elseif ( ! isset( self::ALLOWED_HTML[ $tag ] ) ) {
+					$this->sanitizeChildren( $child );
+					while ( $child->firstChild ) {
+						$parent->insertBefore( $child->firstChild, $child );
+					}
+					$parent->removeChild( $child );
+				} else {
+					$this->sanitizeAttributes( $child, $tag );
+					if ( in_array( $tag, [ 'audio', 'img', 'video' ], true ) && ! $child->hasAttribute( 'src' ) ) {
+						$parent->removeChild( $child );
+					} elseif ( 'input' === $tag && 'checkbox' !== $child->getAttribute( 'type' ) ) {
+						$parent->removeChild( $child );
+					} else {
+						$this->sanitizeChildren( $child );
+					}
+				}
+			} elseif ( XML_COMMENT_NODE === $child->nodeType ) {
+				$parent->removeChild( $child );
+			}
+
+			$child = $next;
+		}
+	}
+
+	/**
+	 * Remove unsupported and invalid attributes.
+	 *
+	 * @param DOMElement $element Element to sanitize.
+	 * @param string     $tag     Element tag.
+	 * @return void
+	 */
+	private function sanitizeAttributes( DOMElement $element, string $tag ) {
+		$allowed = self::ALLOWED_HTML[ $tag ];
+		$names   = [];
+		foreach ( $element->attributes as $attribute ) {
+			$names[] = $attribute->name;
+		}
+
+		foreach ( $names as $name ) {
+			$value = $element->getAttribute( $name );
+			if ( ! isset( $allowed[ $name ] ) || ! $this->isValidAttribute( $tag, $name, $value ) ) {
+				$element->removeAttribute( $name );
+			}
+		}
+	}
+
+	/**
+	 * Validate an attribute value.
+	 *
+	 * @param string $tag   Element tag.
+	 * @param string $name  Attribute name.
+	 * @param string $value Attribute value.
+	 * @return bool
+	 */
+	private function isValidAttribute( string $tag, string $name, string $value ) {
+		if ( 'href' === $name ) {
+			return (bool) preg_match( '~^(?:https?://|mailto:|tel:|tg://user\?id=|#[A-Za-z0-9_.:-]+)~i', $value );
+		}
+
+		if ( 'src' === $name ) {
+			if ( 'img' === $tag && preg_match( '#^tg://emoji\?id=\d+$#', $value ) ) {
+				return true;
+			}
+			return (bool) preg_match( '#^https?://#i', $value );
+		}
+
+		if ( 'class' === $name ) {
+			return 'code' === $tag && (bool) preg_match( '/^language-[A-Za-z0-9_+-]+$/', $value );
+		}
+
+		if ( in_array( $name, [ 'colspan', 'rowspan', 'start', 'unix', 'value', 'zoom' ], true ) ) {
+			return (bool) preg_match( '/^-?\d+$/', $value );
+		}
+
+		if ( in_array( $name, [ 'lat', 'long' ], true ) ) {
+			return is_numeric( $value );
+		}
+
+		if ( 'align' === $name ) {
+			return in_array( $value, [ 'left', 'center', 'right' ], true );
+		}
+
+		if ( 'valign' === $name ) {
+			return in_array( $value, [ 'top', 'middle', 'bottom' ], true );
+		}
+
+		if ( 'type' === $name && 'input' === $tag ) {
+			return 'checkbox' === $value;
+		}
+
+		if ( 'type' === $name ) {
+			return (bool) preg_match( '/^[1aAiI]$/', $value );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get Telegram's logical length for a subtree.
+	 *
+	 * @param DOMNode $node    Root node.
+	 * @param string  $limitBy Length unit.
+	 * @return int
+	 */
+	private function getLogicalLength( DOMNode $node, string $limitBy ) {
+		$text = $this->getLogicalText( $node );
+
+		if ( 'words' === $limitBy ) {
+			preg_match_all( '/[\p{L}\p{N}\p{M}]+(?:[\'’_-][\p{L}\p{N}\p{M}]+)*/u', $text, $matches );
+			return count( $matches[0] );
+		}
+
+		return mb_strlen( $text );
+	}
+
+	/**
+	 * Get logical text including image-form custom emoji fallback text.
+	 *
+	 * @param DOMNode $node Root node.
+	 * @return string
+	 */
+	private function getLogicalText( DOMNode $node ) {
+		if ( $node instanceof DOMText ) {
+			return $node->nodeValue;
+		}
+
+		if ( $node instanceof DOMElement && 'img' === strtolower( $node->tagName ) && 0 === strpos( $node->getAttribute( 'src' ), 'tg://emoji?id=' ) ) {
+			return $node->getAttribute( 'alt' );
+		}
+
+		$text = '';
+		foreach ( $node->childNodes as $child ) {
+			$text .= $this->getLogicalText( $child );
+		}
+		return $text;
+	}
+
+	/**
+	 * Trim descendants to the supplied remaining amount.
+	 *
+	 * @param DOMNode $parent    Parent node.
+	 * @param string  $limitBy   Length unit.
+	 * @param int     $remaining Remaining length.
+	 * @return void
+	 */
+	private function trimNode( DOMNode $parent, string $limitBy, int &$remaining ) {
+		$child = $parent->firstChild;
+		while ( $child ) {
+			$next = $child->nextSibling;
+			if ( 0 >= $remaining ) {
+				$parent->removeChild( $child );
+			} elseif ( $child instanceof DOMText ) {
+				$length = $this->getTextLength( $child->nodeValue, $limitBy );
+				if ( $length > $remaining ) {
+					$child->nodeValue = $this->limitText( $child->nodeValue, $limitBy, $remaining );
+					$remaining        = 0;
+				} else {
+					$remaining -= $length;
+				}
+			} elseif ( $child instanceof DOMElement && 'img' === strtolower( $child->tagName ) && 0 === strpos( $child->getAttribute( 'src' ), 'tg://emoji?id=' ) ) {
+				$length = $this->getTextLength( $child->getAttribute( 'alt' ), $limitBy );
+				if ( $length > $remaining ) {
+					$parent->removeChild( $child );
+					$remaining = 0;
+				} else {
+					$remaining -= $length;
+				}
+			} else {
+				$this->trimNode( $child, $limitBy, $remaining );
+			}
+			$child = $next;
+		}
+	}
+
+	/**
+	 * Get a string length in the selected unit.
+	 *
+	 * @param string $text    Text to measure.
+	 * @param string $limitBy Length unit.
+	 * @return int
+	 */
+	private function getTextLength( string $text, string $limitBy ) {
+		if ( 'words' === $limitBy ) {
+			preg_match_all( '/[\p{L}\p{N}\p{M}]+(?:[\'’_-][\p{L}\p{N}\p{M}]+)*/u', $text, $matches );
+			return count( $matches[0] );
+		}
+		return mb_strlen( $text );
+	}
+
+	/**
+	 * Limit a text node.
+	 *
+	 * @param string $text    Text to limit.
+	 * @param string $limitBy Length unit.
+	 * @param int    $limit   Maximum length.
+	 * @return string
+	 */
+	private function limitText( string $text, string $limitBy, int $limit ) {
+		if ( 'words' !== $limitBy ) {
+			return mb_substr( $text, 0, $limit );
+		}
+
+		if ( ! preg_match_all( '/[\p{L}\p{N}\p{M}]+(?:[\'’_-][\p{L}\p{N}\p{M}]+)*/u', $text, $matches, PREG_OFFSET_CAPTURE ) || count( $matches[0] ) <= $limit ) {
+			return $text;
+		}
+
+		$match = $matches[0][ $limit - 1 ];
+		return substr( $text, 0, $match[1] + strlen( $match[0] ) );
+	}
+
+	/**
+	 * Append an ellipsis inside the final retained block.
+	 *
+	 * @param DOMElement  $root     Root element.
+	 * @param DOMDocument $document DOM document.
+	 * @return void
+	 */
+	private function appendEllipsis( DOMElement $root, DOMDocument $document ) {
+		$target = $root;
+		while ( $target->lastChild instanceof DOMElement && ! in_array( strtolower( $target->lastChild->tagName ), [ 'br', 'hr', 'img', 'input', 'tg-map' ], true ) ) {
+			$target = $target->lastChild;
+		}
+		$target->appendChild( $document->createTextNode( $this->elipsis ) );
+	}
+
+	/**
+	 * Serialize a wrapper's children without the wrapper itself.
+	 *
+	 * @param DOMElement $root Root element.
+	 * @return string
+	 */
+	private function serializeChildren( DOMElement $root ) {
+		$html = '';
+		foreach ( $root->childNodes as $child ) {
+			$html .= $root->ownerDocument->saveHTML( $child );
+		}
+		return trim( $html );
+	}
+}

--- a/packages/php/telegram-format-text/tests/RichHtmlConverterTest.php
+++ b/packages/php/telegram-format-text/tests/RichHtmlConverterTest.php
@@ -70,7 +70,7 @@ it(
 		$input = '<h1>😀😀</h1><p>abcdef <strong>ghij</strong></p><p>removed</p>';
 
 		expect( ( new RichHtmlConverter() )->safeTrim( $input, 'chars', 9 ) )->toBe(
-			'<h1>😀😀</h1><p>abcdef …</p>'
+			'<h1>😀😀</h1><p>abcdef…</p>'
 		);
 	}
 );
@@ -80,9 +80,23 @@ it(
 	function () {
 		$input = '<p>A<img src="tg://emoji?id=123" alt="👍">BC</p>';
 
-		expect( ( new RichHtmlConverter() )->safeTrim( $input, 'chars', 2 ) )->toBe(
+		expect( ( new RichHtmlConverter() )->safeTrim( $input, 'chars', 3 ) )->toBe(
 			'<p>A<img src="tg://emoji?id=123" alt="👍">…</p>'
 		);
+	}
+);
+
+it(
+	'counts the ellipsis toward the requested limit',
+	function () {
+		$converter = new RichHtmlConverter();
+		$input     = '<p>abcdefghij</p><p>more</p>';
+
+		foreach ( [ 1, 2, 5, 9 ] as $limit ) {
+			$trimmed = $converter->safeTrim( $input, 'chars', $limit );
+
+			expect( mb_strlen( strip_tags( $trimmed ) ) )->toBeLessThanOrEqual( $limit );
+		}
 	}
 );
 
@@ -101,15 +115,15 @@ it(
 		$converter = new RichHtmlConverter();
 
 		// The trailing media block is dropped, so the figure must not receive the ellipsis.
-		expect( $converter->safeTrim( '<p>abcde</p><figure><img src="https://example.com/a.jpg"></figure>', 'chars', 3 ) )
+		expect( $converter->safeTrim( '<p>abcde</p><figure><img src="https://example.com/a.jpg"></figure>', 'chars', 4 ) )
 			->toBe( '<p>abc…</p>' );
 
 		// An emptied table must not hold a bare text node.
-		expect( $converter->safeTrim( '<p>abc</p><table><tr><td>defgh</td></tr></table>', 'chars', 3 ) )
+		expect( $converter->safeTrim( '<p>abc</p><table><tr><td>defgh</td></tr></table>', 'chars', 4 ) )
 			->toBe( '<p>abc…</p>' );
 
 		// A partially retained table keeps the ellipsis inside the last cell.
-		expect( $converter->safeTrim( '<table><tr><td>abcdefghij</td></tr></table>', 'chars', 5 ) )
+		expect( $converter->safeTrim( '<table><tr><td>abcdefghij</td></tr></table>', 'chars', 6 ) )
 			->toBe( '<table><tr><td>abcde…</td></tr></table>' );
 	}
 );
@@ -130,6 +144,22 @@ it(
 			. '<mark>m</mark><sub>s</sub><sup>S</sup><tg-spoiler>sp</tg-spoiler></p>';
 
 		expect( ( new RichHtmlConverter() )->convert( $input ) )->toBe( $input );
+	}
+);
+
+it(
+	'validates complete link and media values',
+	function () {
+		$converter = new RichHtmlConverter();
+
+		$valid = '<p><a href="https://example.com/a?b=c#d">a</a><a href="mailto:user@example.com">b</a>'
+			. '<a href="tel:+123456789">c</a><a href="tg://user?id=123456789">d</a><a href="#note-1">e</a></p>';
+
+		expect( $converter->convert( $valid ) )->toBe( $valid );
+
+		// A non-numeric user id and a trailing-garbage URL must lose the attribute and unwrap.
+		expect( $converter->convert( '<p><a href="tg://user?id=abc">a</a><a href="https://ok.test/ b">b</a></p>' ) )
+			->toBe( '<p>ab</p>' );
 	}
 );
 

--- a/packages/php/telegram-format-text/tests/RichHtmlConverterTest.php
+++ b/packages/php/telegram-format-text/tests/RichHtmlConverterTest.php
@@ -26,7 +26,18 @@ it(
 		$input = '<script>alert(1)</script><p onclick="alert(1)">Safe <a href="javascript:alert(1)">link</a></p><img src="data:image/png;base64,x"><video src="ftp://example.com/video.mp4"></video><tg-thinking>Draft</tg-thinking>';
 
 		expect( ( new RichHtmlConverter() )->convert( $input ) )->toBe(
-			'<p>Safe <a>link</a></p>'
+			'<p>Safe link</p>'
+		);
+	}
+);
+
+it(
+	'unwraps semantic tags missing required attributes',
+	function () {
+		$input = '<p><a>Link</a> <tg-emoji>🙂</tg-emoji> <tg-time format="r">Tomorrow</tg-time> <tg-reference>Note</tg-reference></p>';
+
+		expect( ( new RichHtmlConverter() )->convert( $input ) )->toBe(
+			'<p>Link 🙂 Tomorrow Note</p>'
 		);
 	}
 );

--- a/packages/php/telegram-format-text/tests/RichHtmlConverterTest.php
+++ b/packages/php/telegram-format-text/tests/RichHtmlConverterTest.php
@@ -94,3 +94,61 @@ it(
 		expect( ( new RichHtmlConverter() )->safeTrim( $input, 'chars', 5 ) )->toBe( '<p>Hello</p>' );
 	}
 );
+
+it(
+	'keeps the ellipsis out of elements that accept only element children',
+	function () {
+		$converter = new RichHtmlConverter();
+
+		// The trailing media block is dropped, so the figure must not receive the ellipsis.
+		expect( $converter->safeTrim( '<p>abcde</p><figure><img src="https://example.com/a.jpg"></figure>', 'chars', 3 ) )
+			->toBe( '<p>abc…</p>' );
+
+		// An emptied table must not hold a bare text node.
+		expect( $converter->safeTrim( '<p>abc</p><table><tr><td>defgh</td></tr></table>', 'chars', 3 ) )
+			->toBe( '<p>abc…</p>' );
+
+		// A partially retained table keeps the ellipsis inside the last cell.
+		expect( $converter->safeTrim( '<table><tr><td>abcdefghij</td></tr></table>', 'chars', 5 ) )
+			->toBe( '<table><tr><td>abcde…</td></tr></table>' );
+	}
+);
+
+it(
+	'preserves every documented rich block family',
+	function () {
+		$input = '<h1>H</h1><p>Text</p><pre><code class="language-php">echo 1;</code></pre><footer>F</footer><hr>'
+			. '<ul><li><input type="checkbox" checked>Task</li></ul><ol start="2"><li>Item</li></ol>'
+			. '<blockquote>Quote<br>More<cite>Author</cite></blockquote><aside>Pull<cite>Author</cite></aside>'
+			. '<figure><audio src="https://example.com/a.mp3"></audio><figcaption>Cap<cite>Credit</cite></figcaption></figure>'
+			. '<tg-map lat="41.9" long="12.5" zoom="14"></tg-map><tg-collage><img src="https://example.com/a.jpg"></tg-collage>'
+			. '<tg-slideshow><video src="https://example.com/v.mp4"></video></tg-slideshow>'
+			. '<table bordered><caption>C</caption><tr><th>H</th></tr><tr><td>V</td></tr></table>'
+			. '<details open><summary>S</summary>Body</details><tg-math-block>E = mc^2</tg-math-block>'
+			. '<p><tg-emoji emoji-id="5368324170671202286"></tg-emoji><tg-time unix="1647531900" format="wDT">soon</tg-time>'
+			. '<tg-math>x^2</tg-math><tg-reference name="note-1">Ref</tg-reference><a href="#note-1">Link</a>'
+			. '<mark>m</mark><sub>s</sub><sup>S</sup><tg-spoiler>sp</tg-spoiler></p>';
+
+		expect( ( new RichHtmlConverter() )->convert( $input ) )->toBe( $input );
+	}
+);
+
+it(
+	'drops table sections that Telegram does not support',
+	function () {
+		$input = '<table><thead><tr><th>H</th></tr></thead><tbody><tr><td>C</td></tr></tbody></table>';
+
+		expect( ( new RichHtmlConverter() )->convert( $input ) )->toBe( '<table><tr><th>H</th></tr><tr><td>C</td></tr></table>' );
+	}
+);
+
+it(
+	'restores the libxml error state',
+	function () {
+		$previous = libxml_use_internal_errors( false );
+
+		( new RichHtmlConverter() )->convert( '<p>Hello</p>' );
+
+		expect( libxml_use_internal_errors( $previous ) )->toBeFalse();
+	}
+);

--- a/packages/php/telegram-format-text/tests/RichHtmlConverterTest.php
+++ b/packages/php/telegram-format-text/tests/RichHtmlConverterTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Tests for the RichHtmlConverter class.
+ *
+ * @package WPSocio\TelegramFormatText
+ */
+
+namespace WPSocio\TelegramFormatText\Tests;
+
+use WPSocio\TelegramFormatText\RichHtmlConverter;
+
+it(
+	'preserves supported rich structure and removes WordPress wrappers',
+	function () {
+		$input = '<div class="wp-block-group"><h1 style="color:red">Title</h1><p>Text <mark>marked</mark>.</p><figure class="wp-block-image"><img src="https://example.com/image.jpg" class="size-large"><figcaption>Caption <cite>Credit</cite></figcaption></figure></div>';
+
+		expect( ( new RichHtmlConverter() )->convert( $input ) )->toBe(
+			'<h1>Title</h1><p>Text <mark>marked</mark>.</p><figure><img src="https://example.com/image.jpg"><figcaption>Caption <cite>Credit</cite></figcaption></figure>'
+		);
+	}
+);
+
+it(
+	'removes unsafe elements attributes and media URLs',
+	function () {
+		$input = '<script>alert(1)</script><p onclick="alert(1)">Safe <a href="javascript:alert(1)">link</a></p><img src="data:image/png;base64,x"><video src="ftp://example.com/video.mp4"></video><tg-thinking>Draft</tg-thinking>';
+
+		expect( ( new RichHtmlConverter() )->convert( $input ) )->toBe(
+			'<p>Safe <a>link</a></p>'
+		);
+	}
+);
+
+it(
+	'preserves documented attributes only when valid',
+	function () {
+		$input = '<ol start="3" type="a" reversed class="list"><li value="7" type="i">Item</li></ol><table bordered striped><tr><td colspan="2" align="center" valign="bottom">Cell</td></tr></table><details open><summary>More</summary>Body</details>';
+
+		expect( ( new RichHtmlConverter() )->convert( $input ) )->toBe(
+			'<ol start="3" type="a" reversed><li value="7" type="i">Item</li></ol><table bordered striped><tr><td colspan="2" align="center" valign="bottom">Cell</td></tr></table><details open><summary>More</summary>Body</details>'
+		);
+	}
+);
+
+it(
+	'is idempotent',
+	function () {
+		$converter = new RichHtmlConverter();
+		$input     = '<h2>Title</h2><p>Nested <strong>content</strong>.</p>';
+		$output    = $converter->convert( $input );
+
+		expect( $converter->convert( $output ) )->toBe( $output );
+	}
+);
+
+it(
+	'safely trims unicode content and balances elements',
+	function () {
+		$input = '<h1>😀😀</h1><p>abcdef <strong>ghij</strong></p><p>removed</p>';
+
+		expect( ( new RichHtmlConverter() )->safeTrim( $input, 'chars', 9 ) )->toBe(
+			'<h1>😀😀</h1><p>abcdef …</p>'
+		);
+	}
+);
+
+it(
+	'counts custom emoji alternative text toward the limit',
+	function () {
+		$input = '<p>A<img src="tg://emoji?id=123" alt="👍">BC</p>';
+
+		expect( ( new RichHtmlConverter() )->safeTrim( $input, 'chars', 2 ) )->toBe(
+			'<p>A<img src="tg://emoji?id=123" alt="👍">…</p>'
+		);
+	}
+);
+
+it(
+	'returns converted content unchanged when under the limit',
+	function () {
+		$input = '<div><p>Hello</p></div>';
+
+		expect( ( new RichHtmlConverter() )->safeTrim( $input, 'chars', 5 ) )->toBe( '<p>Hello</p>' );
+	}
+);


### PR DESCRIPTION
## Summary

- add a dedicated Rich HTML converter for Telegram Rich Messages
- let shared formatting controls accept product-specific options and documentation
- support disabling image and single-message controls without clearing saved values
- add converter coverage for sanitization, required attributes, trimming, and idempotence

## Validation

- `composer test` — 63 tests passed
- `composer lint:skip-warnings`
- shared UI TypeScript check
- focused Biome checks

### Remote Refs

<!--- REMOTE REFS START -->

premium: feat/telegram-rich-messages

<!--- REMOTE REFS END -->