### PR TITLE
fix(ci): serialize composer installs to avoid cache dir race

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -48,7 +48,8 @@ jobs:
         # So, let us install them in src/temp to avoid their exclusion inside vendor
         run: |
           pnpm -r --parallel ${{ env.PNPM_FILTER }} exec composer config vendor-dir src/temp
-          pnpm -r --parallel ${{ env.PNPM_FILTER }} exec composer install --no-dev
+          # Serialized: concurrent composer processes race on the shared cache dir
+          pnpm -r --workspace-concurrency=1 ${{ env.PNPM_FILTER }} exec composer install --no-dev
 
           find ${{ env.FIND_PATHS }} ${{ env.FIND_IGNORE }} -type f -name '*.php' -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
 

--- a/package.json
+++ b/package.json
@@ -126,13 +126,16 @@
 			]
 		},
 		"setup:php:packages": {
-			"command": "pnpm -r --filter=./packages/php/* run setup:php"
+			"command": "pnpm -r --workspace-concurrency=1 --filter=./packages/php/* run setup:php",
+			"dependencies": [
+				"setup:php:root"
+			]
 		},
 		"setup:php:root": {
 			"command": "composer install --ignore-platform-reqs"
 		},
 		"setup:php:projects": {
-			"command": "pnpm -r --filter=./plugins/* --filter=./premium/*/* run setup:php",
+			"command": "pnpm -r --workspace-concurrency=1 --filter=./plugins/* --filter=./premium/*/* run setup:php",
 			"dependencies": [
 				"setup:php:packages"
 			]


### PR DESCRIPTION
Fixes the intermittent `Setup PHP` failures in CI.

Multiple `composer install` processes were running concurrently against the same Composer cache dir (`~/.cache/composer`). Composer doesn't lock cache directory creation, so two processes downloading packages at the same time can race on `mkdir` and one fails:

```
Failed to download phpdocumentor/type-resolver from dist:
/home/runner/.cache/composer/files/phpdocumentor/type-resolver does not exist and could not be created:
```

Two places did this:

- `setup:php` — wireit ran `setup:php:root` and `setup:php:packages` in parallel, and each `pnpm -r` group ran its packages in parallel.
- The `Check syntax errors` CI step — `pnpm -r --parallel ... exec composer install --no-dev`.

Both now run composer serially (`--workspace-concurrency=1`, plus a `setup:php:root` → `setup:php:packages` dependency). The cache stays shared, so later installs are still cache hits — only the concurrency is removed.

### Remote Refs

<!--- REMOTE REFS START -->

premium: main

<!--- REMOTE REFS END -->
