### PR TITLE
chore: add a clean script that delegates to workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"build:projects": "wireit",
 		"bundle:all": "wpdev bundle --all",
 		"bundle:changed": "wireit",
+		"clean": "pnpm -r --if-present --no-bail run clean && rimraf .wireit ./artifacts dist changeset-status.json",
 		"dev": "wireit",
 		"dev:cleanup": "wireit",
 		"env-start": "wp-env start",
@@ -169,11 +170,6 @@
 		"envFiles": [
 			".env"
 		]
-	},
-	"pnpm": {
-		"overrides": {
-			"vite": "6.2.1"
-		}
 	},
 	"packageManager": "pnpm@10.26.2"
 }

--- a/packages/php/telegram-format-text/package.json
+++ b/packages/php/telegram-format-text/package.json
@@ -4,8 +4,12 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
+		"clean": "rimraf .phpunit.cache .phpunit.result.cache",
 		"lint:php": "composer run lint",
 		"test:php": "composer run test",
 		"setup:php": "composer install --ignore-platform-reqs"
+	},
+	"devDependencies": {
+		"rimraf": "^6.1.2"
 	}
 }

--- a/packages/php/wp-utils/package.json
+++ b/packages/php/wp-utils/package.json
@@ -4,8 +4,12 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
+		"clean": "rimraf .phpunit.cache .phpunit.result.cache",
 		"lint:php": "composer run lint",
 		"test:php": "composer run test",
 		"setup:php": "composer install --ignore-platform-reqs"
+	},
+	"devDependencies": {
+		"rimraf": "^6.1.2"
 	}
 }

--- a/plugins/wptelegram-comments/package.json
+++ b/plugins/wptelegram-comments/package.json
@@ -28,6 +28,7 @@
 	"scripts": {
 		"dev": "vite --port=5003",
 		"build": "wireit",
+		"clean": "rimraf .wireit src/assets/build src/languages/js-translations.pot .phpunit.cache .phpunit.result.cache",
 		"lint:php": "composer run lint",
 		"setup:php": "wireit",
 		"setup:php:prod": "wireit",
@@ -49,6 +50,7 @@
 		"@types/react": "^18.3.27",
 		"@types/react-dom": "^18.3.7",
 		"@wpsocio/vite-wp-react": "workspace:*",
+		"rimraf": "^6.1.2",
 		"tailwindcss": "^4.3.3",
 		"tailwindcss-scoped-preflight": "^4.0.6",
 		"typescript": "^5.9.3",

--- a/plugins/wptelegram-login/package.json
+++ b/plugins/wptelegram-login/package.json
@@ -21,6 +21,7 @@
 	"scripts": {
 		"dev": "vite --port=5004",
 		"build": "wireit",
+		"clean": "rimraf .wireit src/assets/build src/languages/js-translations.pot .phpunit.cache .phpunit.result.cache",
 		"lint:php": "composer run lint",
 		"setup:php": "wireit",
 		"setup:php:prod": "wireit",
@@ -49,6 +50,7 @@
 		"@types/wordpress__block-editor": "^14.21.7",
 		"@types/wordpress__blocks": "^12.5.18",
 		"@wpsocio/vite-wp-react": "workspace:*",
+		"rimraf": "^6.1.2",
 		"tailwindcss": "^4.3.3",
 		"tailwindcss-scoped-preflight": "^4.0.6",
 		"typescript": "^5.9.3",

--- a/plugins/wptelegram-widget/package.json
+++ b/plugins/wptelegram-widget/package.json
@@ -21,6 +21,7 @@
 	"scripts": {
 		"dev": "vite --port=5006",
 		"build": "wireit",
+		"clean": "rimraf .wireit src/assets/build src/languages/js-translations.pot .phpunit.cache .phpunit.result.cache",
 		"lint:php": "composer run lint",
 		"setup:php": "wireit",
 		"setup:php:prod": "wireit",
@@ -50,6 +51,7 @@
 		"@types/wordpress__block-editor": "^14.21.7",
 		"@types/wordpress__blocks": "^12.5.18",
 		"@wpsocio/vite-wp-react": "workspace:*",
+		"rimraf": "^6.1.2",
 		"tailwindcss": "^4.3.3",
 		"tailwindcss-scoped-preflight": "^4.0.6",
 		"typescript": "^5.9.3",

--- a/plugins/wptelegram/package.json
+++ b/plugins/wptelegram/package.json
@@ -21,6 +21,7 @@
 	"scripts": {
 		"dev": "vite --port=5002",
 		"build": "wireit",
+		"clean": "rimraf .wireit src/assets/build src/languages/js-translations.pot .phpunit.cache .phpunit.result.cache",
 		"lint:php": "composer run lint",
 		"setup:php": "wireit",
 		"setup:php:prod": "wireit",
@@ -53,6 +54,7 @@
 		"@types/react-dom": "^18.3.7",
 		"@types/wordpress__edit-post": "^8.4.2",
 		"@wpsocio/vite-wp-react": "workspace:*",
+		"rimraf": "^6.1.2",
 		"tailwindcss": "^4.3.3",
 		"tailwindcss-scoped-preflight": "^4.0.6",
 		"typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,9 +364,17 @@ importers:
         specifier: ^18.3.27
         version: 18.3.27
 
-  packages/php/telegram-format-text: {}
+  packages/php/telegram-format-text:
+    devDependencies:
+      rimraf:
+        specifier: ^6.1.2
+        version: 6.1.2
 
-  packages/php/wp-utils: {}
+  packages/php/wp-utils:
+    devDependencies:
+      rimraf:
+        specifier: ^6.1.2
+        version: 6.1.2
 
   packages/php/wptelegram-bot-api: {}
 
@@ -439,6 +447,9 @@ importers:
       '@wpsocio/vite-wp-react':
         specifier: workspace:*
         version: link:../../tools/vite-wp-react
+      rimraf:
+        specifier: ^6.1.2
+        version: 6.1.2
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -494,6 +505,9 @@ importers:
       '@wpsocio/vite-wp-react':
         specifier: workspace:*
         version: link:../../tools/vite-wp-react
+      rimraf:
+        specifier: ^6.1.2
+        version: 6.1.2
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -567,6 +581,9 @@ importers:
       '@wpsocio/vite-wp-react':
         specifier: workspace:*
         version: link:../../tools/vite-wp-react
+      rimraf:
+        specifier: ^6.1.2
+        version: 6.1.2
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -646,6 +663,9 @@ importers:
       '@wpsocio/vite-wp-react':
         specifier: workspace:*
         version: link:../../tools/vite-wp-react
+      rimraf:
+        specifier: ^6.1.2
+        version: 6.1.2
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -682,6 +702,9 @@ importers:
       '@wpsocio/e2e-utils':
         specifier: workspace:*
         version: link:../tools/e2e-utils
+      rimraf:
+        specifier: ^6.1.2
+        version: 6.1.2
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -767,6 +790,9 @@ importers:
       '@wpsocio/vite-wp-react':
         specifier: workspace:*
         version: link:../../../tools/vite-wp-react
+      rimraf:
+        specifier: ^6.1.2
+        version: 6.1.2
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -18378,17 +18404,17 @@ snapshots:
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.97.1))(webpack@5.97.1)':
     dependencies:
       webpack: 5.97.1(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2(webpack-cli@5.1.4)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.97.1))(webpack@5.97.1)':
     dependencies:
       webpack: 5.97.1(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2(webpack-cli@5.1.4)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.97.1))(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       webpack: 5.97.1(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2(webpack-cli@5.1.4)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))
     optionalDependencies:
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.97.1)
 
@@ -19827,7 +19853,7 @@ snapshots:
       url-loader: 4.1.1(webpack@5.97.1)
       webpack: 5.97.1(webpack-cli@5.1.4)
       webpack-bundle-analyzer: 4.10.2
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2(webpack-cli@5.1.4)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.97.1)
     optionalDependencies:
       '@wordpress/env': 10.37.0(@types/node@25.0.3)
@@ -27125,7 +27151,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.97.1):
+  webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2(webpack-cli@5.1.4)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4)):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.97.1))(webpack@5.97.1)
@@ -27188,7 +27214,7 @@ snapshots:
       ws: 8.18.0
     optionalDependencies:
       webpack: 5.97.1(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2(webpack-cli@5.1.4)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -27229,7 +27255,7 @@ snapshots:
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2(webpack-cli@5.1.4)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,6 @@ packages:
     - "premium"
     - "premium/plugins/*"
     - "tools/*"
+
+overrides:
+    vite: "6.2.1"

--- a/tools/e2e-utils/package.json
+++ b/tools/e2e-utils/package.json
@@ -29,6 +29,7 @@
 		"typescript": "^5.9.3"
 	},
 	"scripts": {
+		"clean": "rimraf tsconfig.tsbuildinfo",
 		"typecheck": "tsc --noEmit"
 	}
 }

--- a/tools/wpdev/package.json
+++ b/tools/wpdev/package.json
@@ -64,6 +64,7 @@
 		"@types/gettext-parser": "^8.0.0",
 		"@types/semver": "^7.7.1",
 		"oclif": "^4.22.61",
+		"rimraf": "^6.1.2",
 		"tsup": "^8.5.1",
 		"typescript": "^5.9.3",
 		"wireit": "^0.14.12"


### PR DESCRIPTION
Adds a `clean` script that removes build artifacts across the workspace, and moves `pnpm.overrides` out of `package.json` into `pnpm-workspace.yaml`, where pnpm 10 reads it from.

Each workspace owns a `clean` script for its own artifacts; the root script delegates via `pnpm -r` and then clears its own. `--if-present` keeps pnpm from erroring on packages without the script, `--no-bail` keeps one failure from aborting the rest.

| Scope | Removes |
| --- | --- |
| root | `.wireit`, `artifacts`, `dist`, `changeset-status.json` |
| `plugins/*` | `.wireit`, `src/assets/build`, `src/languages/js-translations.pot`, phpunit caches |
| `packages/php/*` | phpunit caches |
| `tools/*` | `dist`, `tsconfig.tsbuildinfo`, `.wireit` |

`rimraf` is declared as a devDependency wherever it is used, instead of relying on the root binary being on `PATH`. `node_modules` and `vendor` are left alone — `wpdev clean` already covers those.

The lockfile also picks up unrelated `webpack-cli` peer resolution churn from the current pnpm version.

### Remote Refs

<!--- REMOTE REFS START -->

premium: chore/clean-script

<!--- REMOTE REFS END -->
