### PR TITLE
fix(ci): run E2E against WP 6.7, the declared minimum

### DIFF
--- a/.github/scripts/requirements.js
+++ b/.github/scripts/requirements.js
@@ -1,0 +1,31 @@
+// @ts-check
+
+/**
+ * Exposes the PHP/WP versions from the shared bundle config as workflow outputs,
+ * so that the CI matrices don't have to duplicate them.
+ */
+
+import { appendFileSync } from 'node:fs';
+import { phpVersions, wpVersions } from '../../config/wpdev.base.project.js';
+
+const outputs = {
+	'php-all': JSON.stringify(phpVersions),
+	'php-min': phpVersions[0],
+	'php-max': phpVersions[phpVersions.length - 1],
+	'wp-all': JSON.stringify(wpVersions),
+};
+
+const { GITHUB_OUTPUT } = process.env;
+
+if (!GITHUB_OUTPUT) {
+	throw new Error('GITHUB_OUTPUT is not set.');
+}
+
+// Single line values, so no need for the heredoc syntax
+const contents = Object.entries(outputs)
+	.map(([key, value]) => `${key}=${value}`)
+	.join('\n');
+
+console.log(contents);
+
+appendFileSync(GITHUB_OUTPUT, `${contents}\n`);

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -125,7 +125,7 @@ jobs:
       matrix:
         # Least version required and the latest version
         php: ["8.0", "8.5"]
-        wp: ["6.6", "master"]
+        wp: ["6.7", "master"]
 
     steps:
       - name: Checkout this repo

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,14 +5,34 @@ on:
     types: [opened, synchronize]
 
 jobs:
+  requirements:
+    name: "Read the requirements"
+    if: github.repository == 'wpsocio/wp-projects'
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    outputs:
+      php-all: ${{ steps.read.outputs.php-all }}
+      php-min: ${{ steps.read.outputs.php-min }}
+      php-max: ${{ steps.read.outputs.php-max }}
+      wp-all: ${{ steps.read.outputs.wp-all }}
+
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+
+      - name: Read the versions from the shared bundle config
+        id: read
+        run: node .github/scripts/requirements.js
+
   php-lint-test:
     name: "PHP ${{ matrix.php }}: Lint, Test"
     if: github.repository == 'wpsocio/wp-projects'
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    needs: requirements
     strategy:
       matrix:
-        php: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+        php: ${{ fromJSON(needs.requirements.outputs.php-all) }}
     env:
       RUN_TESTS: ${{ matrix.php == '8.4' || matrix.php == '8.5' }}
     steps:
@@ -121,11 +141,16 @@ jobs:
     if: github.repository == 'wpsocio/wp-projects'
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    needs: requirements
     strategy:
       matrix:
         # Least version required and the latest version
-        php: ["8.0", "8.5"]
-        wp: ["6.7", "master"]
+        php:
+          [
+            "${{ needs.requirements.outputs.php-min }}",
+            "${{ needs.requirements.outputs.php-max }}",
+          ]
+        wp: ${{ fromJSON(needs.requirements.outputs.wp-all) }}
 
     steps:
       - name: Checkout this repo

--- a/config/wpdev.base.project.js
+++ b/config/wpdev.base.project.js
@@ -1,6 +1,18 @@
 // @ts-check
 
 /**
+ * PHP versions the CI matrices run against.
+ * The first one is the minimum required, the last one is the latest.
+ */
+export const phpVersions = ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5'];
+
+/**
+ * WordPress versions the CI matrices run against.
+ * The first one is the minimum required.
+ */
+export const wpVersions = ['6.7', 'master'];
+
+/**
  * @type {import("@wpsocio/wpdev").ProjectConfig['getBundleConfig']}
  */
 export const getBundleConfig = ({ slug, key, version, textDomain }) => {
@@ -18,9 +30,8 @@ export const getBundleConfig = ({ slug, key, version, textDomain }) => {
 				type: 'update-requirements',
 				data: {
 					requirements: {
-						// When updating these values, also update them in the E2E test workflow
-						requiresPHP: '8.0',
-						requiresAtLeast: '6.7',
+						requiresPHP: phpVersions[0],
+						requiresAtLeast: wpVersions[0],
 						testedUpTo: '7.0.2',
 					},
 					target: {


### PR DESCRIPTION
The minimum supported WordPress version was bumped to 6.7 in #324 (`config/wpdev.base.project.js` → `requiresAtLeast`), but the E2E matrix still ran the oldest job on WP 6.6. The plugins refuse to activate there, so every spec fails with:

```
plugin_wp_incompatible: Current WordPress version (6.6) does not meet minimum requirements for WP Telegram. The plugin requires WordPress 6.7.
```

- Bumps the E2E matrix to WP 6.7.
- Removes the duplication that caused the drift: `phpVersions` and `wpVersions` are now declared once in `config/wpdev.base.project.js`, and `requiresPHP`/`requiresAtLeast` are derived from them. A `requirements` job reads them via `.github/scripts/requirements.js` and feeds both the PHP lint/test matrix and the E2E matrix.

`RUN_TESTS` still hardcodes the two PHP versions that run the PHP test suite.

### Remote Refs

<!--- REMOTE REFS START -->

premium: fix/e2e-min-wp-version

<!--- REMOTE REFS END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
