### PR TITLE
chore: upgrade TypeScript to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"rimraf": "^6.1.2",
 		"tailwindcss": "^4.3.3",
 		"ts-node": "^10.9.2",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"wireit": "^0.14.12"
 	},
 	"wireit": {

--- a/packages/js/shared-ui/package.json
+++ b/packages/js/shared-ui/package.json
@@ -26,6 +26,6 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"tailwindcss": "^4.3.3",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	}
 }

--- a/packages/js/shared-ui/tsconfig.json
+++ b/packages/js/shared-ui/tsconfig.json
@@ -7,6 +7,7 @@
 		"esModuleInterop": true,
 		"allowSyntheticDefaultImports": true,
 		"moduleResolution": "NodeNext",
-		"module": "NodeNext"
+		"module": "NodeNext",
+		"types": ["node"]
 	}
 }

--- a/packages/js/tsconfig.json
+++ b/packages/js/tsconfig.json
@@ -7,6 +7,7 @@
 		"jsx": "preserve",
 		"moduleResolution": "Bundler",
 		"module": "ESNext",
-		"noEmit": true
+		"noEmit": true,
+		"types": ["node"]
 	}
 }

--- a/packages/js/ui/package.json
+++ b/packages/js/ui/package.json
@@ -68,6 +68,6 @@
 		"shadcn": "^3.6.2",
 		"tailwindcss": "^4.3.3",
 		"tailwindcss-scoped-preflight": "^4.0.6",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	}
 }

--- a/packages/js/ui/tsconfig.json
+++ b/packages/js/ui/tsconfig.json
@@ -7,7 +7,6 @@
 		"allowSyntheticDefaultImports": true,
 		"moduleResolution": "NodeNext",
 		"module": "NodeNext",
-		"baseUrl": ".",
 		"paths": {
 			"@wpsocio/ui/*": ["./src/*"]
 		}

--- a/plugins/tsconfig.json
+++ b/plugins/tsconfig.json
@@ -1,3 +1,6 @@
 {
-	"extends": "../config/tsconfig.react.json"
+	"extends": "../config/tsconfig.react.json",
+	"compilerOptions": {
+		"types": ["vite/client"]
+	}
 }

--- a/plugins/wptelegram-comments/package.json
+++ b/plugins/wptelegram-comments/package.json
@@ -53,7 +53,7 @@
 		"rimraf": "^6.1.2",
 		"tailwindcss": "^4.3.3",
 		"tailwindcss-scoped-preflight": "^4.0.6",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vite": "^8.2.0",
 		"wireit": "^0.14.12"
 	},

--- a/plugins/wptelegram-login/package.json
+++ b/plugins/wptelegram-login/package.json
@@ -53,7 +53,7 @@
 		"rimraf": "^6.1.2",
 		"tailwindcss": "^4.3.3",
 		"tailwindcss-scoped-preflight": "^4.0.6",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vite": "^8.2.0",
 		"wireit": "^0.14.12"
 	},

--- a/plugins/wptelegram-widget/package.json
+++ b/plugins/wptelegram-widget/package.json
@@ -54,7 +54,7 @@
 		"rimraf": "^6.1.2",
 		"tailwindcss": "^4.3.3",
 		"tailwindcss-scoped-preflight": "^4.0.6",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vite": "^8.2.0",
 		"wireit": "^0.14.12"
 	},

--- a/plugins/wptelegram/package.json
+++ b/plugins/wptelegram/package.json
@@ -57,7 +57,7 @@
 		"rimraf": "^6.1.2",
 		"tailwindcss": "^4.3.3",
 		"tailwindcss-scoped-preflight": "^4.0.6",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vite": "^8.2.0",
 		"wireit": "^0.14.12"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,7 +237,7 @@ importers:
         version: 10.37.0(@types/node@25.0.3)(supports-color@8.1.1)
       '@wordpress/scripts':
         specifier: ^31.2.0
-        version: 31.2.0(@playwright/test@1.57.0)(@types/eslint@9.6.1)(@types/node@25.0.3)(@wordpress/env@10.37.0(@types/node@25.0.3)(supports-color@8.1.1))(babel-plugin-macros@3.1.0)(debug@4.4.3(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint-scss@6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3)))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(type-fest@4.39.1)(typescript@5.9.3)
+        version: 31.2.0(@playwright/test@1.57.0)(@types/eslint@9.6.1)(@types/node@25.0.3)(@wordpress/env@10.37.0(@types/node@25.0.3)(supports-color@8.1.1))(babel-plugin-macros@3.1.0)(debug@4.4.3(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint-scss@6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3)))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))(type-fest@4.39.1)(typescript@6.0.3)
       '@wpsocio/e2e-utils':
         specifier: workspace:*
         version: link:tools/e2e-utils
@@ -255,10 +255,10 @@ importers:
         version: 4.3.3
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.0.3)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.0.3)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       wireit:
         specifier: ^0.14.12
         version: 0.14.12
@@ -398,8 +398,8 @@ importers:
         specifier: ^4.3.3
         version: 4.3.3
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/js/ui:
     dependencies:
@@ -529,7 +529,7 @@ importers:
         version: 5.0.3(postcss@8.5.6)
       shadcn:
         specifier: ^3.6.2
-        version: 3.6.2(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 3.6.2(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(typescript@6.0.3)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -537,8 +537,8 @@ importers:
         specifier: ^4.0.6
         version: 4.0.6(postcss@8.5.6)(tailwindcss@4.3.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/js/utilities:
     dependencies:
@@ -658,8 +658,8 @@ importers:
         specifier: ^4.0.6
         version: 4.0.6(postcss@8.5.25)(tailwindcss@4.3.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@25.0.3)(jiti@2.7.0)(sass@1.81.0)(terser@5.34.1)
@@ -716,8 +716,8 @@ importers:
         specifier: ^4.0.6
         version: 4.0.6(postcss@8.5.25)(tailwindcss@4.3.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@25.0.3)(jiti@2.7.0)(sass@1.81.0)(terser@5.34.1)
@@ -792,8 +792,8 @@ importers:
         specifier: ^4.0.6
         version: 4.0.6(postcss@8.5.25)(tailwindcss@4.3.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@25.0.3)(jiti@2.7.0)(sass@1.81.0)(terser@5.34.1)
@@ -874,8 +874,8 @@ importers:
         specifier: ^4.0.6
         version: 4.0.6(postcss@8.5.25)(tailwindcss@4.3.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@25.0.3)(jiti@2.7.0)(sass@1.81.0)(terser@5.34.1)
@@ -899,7 +899,7 @@ importers:
         version: 10.37.0(@types/node@25.0.3)(supports-color@8.1.1)
       '@wordpress/scripts':
         specifier: ^31.2.0
-        version: 31.2.0(@playwright/test@1.57.0)(@types/eslint@9.6.1)(@types/node@25.0.3)(@wordpress/env@10.37.0(@types/node@25.0.3)(supports-color@8.1.1))(babel-plugin-macros@3.1.0)(debug@4.4.3(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint-scss@6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3)))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(type-fest@4.39.1)(typescript@5.9.3)
+        version: 31.2.0(@playwright/test@1.57.0)(@types/eslint@9.6.1)(@types/node@25.0.3)(@wordpress/env@10.37.0(@types/node@25.0.3)(supports-color@8.1.1))(babel-plugin-macros@3.1.0)(debug@4.4.3(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint-scss@6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3)))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))(type-fest@4.39.1)(typescript@6.0.3)
       '@wpsocio/e2e-utils':
         specifier: workspace:*
         version: link:../tools/e2e-utils
@@ -907,8 +907,8 @@ importers:
         specifier: ^6.1.2
         version: 6.1.2
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       wireit:
         specifier: ^0.14.12
         version: 0.14.12
@@ -1001,8 +1001,8 @@ importers:
         specifier: ^4.0.6
         version: 4.0.6(postcss@8.5.25)(tailwindcss@4.3.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@25.0.3)(jiti@2.7.0)(sass@1.81.0)(terser@5.34.1)
@@ -1019,12 +1019,15 @@ importers:
         specifier: ^1.37.0
         version: 1.37.0(@playwright/test@1.57.0)(supports-color@8.1.1)
     devDependencies:
+      '@types/node':
+        specifier: ^25.0.3
+        version: 25.0.3
       rimraf:
         specifier: ^6.1.2
         version: 6.1.2
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   tools/vite-wp-react:
     dependencies:
@@ -1046,10 +1049,10 @@ importers:
         version: 6.1.2
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(typescript@5.9.3)
+        version: 0.22.14(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@25.0.3)(jiti@2.7.0)(sass@1.81.0)(terser@5.34.1)
@@ -1134,10 +1137,10 @@ importers:
         version: 4.22.61(@types/node@25.0.3)(supports-color@8.1.1)
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(typescript@5.9.3)
+        version: 0.22.14(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       wireit:
         specifier: ^0.14.12
         version: 0.14.12
@@ -11867,8 +11870,8 @@ packages:
   types-ramda@0.31.0:
     resolution: {integrity: sha512-vaoC35CRC3xvL8Z6HkshDbi6KWM1ezK0LHN0YyxXWUn9HKzBNg/T3xSGlJZjCYspnOD3jE7bcizsp0bUXZDxnQ==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -15604,7 +15607,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0(supports-color@8.1.1)
@@ -15618,7 +15621,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -17307,7 +17310,7 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@stylistic/stylelint-plugin@3.1.1(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3))':
+  '@stylistic/stylelint-plugin@3.1.1(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3))':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.2(@csstools/css-tokenizer@3.0.2)
       '@csstools/css-tokenizer': 3.0.2
@@ -17316,7 +17319,7 @@ snapshots:
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
       style-search: 0.1.0
-      stylelint: 16.9.0(supports-color@8.1.1)(typescript@5.9.3)
+      stylelint: 16.9.0(supports-color@8.1.1)(typescript@6.0.3)
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.26.10(supports-color@8.1.1))':
     dependencies:
@@ -17362,12 +17365,12 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.26.10(supports-color@8.1.1))
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.26.10(supports-color@8.1.1))
 
-  '@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3)':
+  '@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.26.10(supports-color@8.1.1)
       '@svgr/babel-preset': 8.1.0(@babel/core@7.26.10(supports-color@8.1.1))
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.9.3)
+      cosmiconfig: 8.3.6(typescript@6.0.3)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -17378,35 +17381,35 @@ snapshots:
       '@babel/types': 7.29.7
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.26.10(supports-color@8.1.1)
       '@svgr/babel-preset': 8.1.0(@babel/core@7.26.10(supports-color@8.1.1))
-      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(typescript@5.9.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
-      cosmiconfig: 8.3.6(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
+      cosmiconfig: 8.3.6(typescript@6.0.3)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/webpack@8.1.0(supports-color@8.1.1)(typescript@5.9.3)':
+  '@svgr/webpack@8.1.0(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.26.10(supports-color@8.1.1)
       '@babel/plugin-transform-react-constant-elements': 7.25.7(@babel/core@7.26.10(supports-color@8.1.1))
       '@babel/preset-env': 7.25.8(@babel/core@7.26.10(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/preset-react': 7.25.7(@babel/core@7.26.10(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/preset-typescript': 7.25.7(@babel/core@7.26.10(supports-color@8.1.1))(supports-color@8.1.1)
-      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3))(supports-color@8.1.1)
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3))(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -17867,13 +17870,13 @@ snapshots:
       '@types/node': 25.0.3
     optional: true
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.1
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.1(supports-color@8.1.1)
@@ -17881,22 +17884,22 @@ snapshots:
       ignore: 5.3.2
       natural-compare: 1.4.0
       semver: 7.7.3
-      ts-api-utils: 1.3.0(typescript@5.9.3)
+      ts-api-utils: 1.3.0(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.1(supports-color@8.1.1)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -17910,15 +17913,15 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
 
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.1(supports-color@8.1.1)
-      ts-api-utils: 1.3.0(typescript@5.9.3)
+      ts-api-utils: 1.3.0(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -17926,7 +17929,7 @@ snapshots:
 
   '@typescript-eslint/types@6.21.0': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@5.62.0(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -17934,13 +17937,13 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.3
-      tsutils: 3.21.0(typescript@5.9.3)
+      tsutils: 3.21.0(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@6.21.0(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@6.21.0(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
@@ -17949,20 +17952,20 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.7.3
-      ts-api-utils: 1.3.0(typescript@5.9.3)
+      ts-api-utils: 1.3.0(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1(supports-color@8.1.1))
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 8.57.1(supports-color@8.1.1)
       eslint-scope: 5.1.1
       semver: 7.7.3
@@ -17970,14 +17973,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1(supports-color@8.1.1))
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 8.57.1(supports-color@8.1.1)
       semver: 7.7.3
     transitivePeerDependencies:
@@ -18989,23 +18992,23 @@ snapshots:
 
   '@wordpress/escape-html@3.37.0': {}
 
-  '@wordpress/eslint-plugin@23.0.0(@babel/core@7.25.7(supports-color@8.1.1))(@types/eslint@9.6.1)(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3)(wp-prettier@3.0.3)':
+  '@wordpress/eslint-plugin@23.0.0(@babel/core@7.25.7(supports-color@8.1.1))(@types/eslint@9.6.1)(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)))(supports-color@8.1.1)(typescript@6.0.3)(wp-prettier@3.0.3)':
     dependencies:
       '@babel/core': 7.25.7(supports-color@8.1.1)
       '@babel/eslint-parser': 7.25.7(@babel/core@7.25.7(supports-color@8.1.1))(eslint@8.57.1(supports-color@8.1.1))
-      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@wordpress/babel-preset-default': 8.37.0(supports-color@8.1.1)
       '@wordpress/prettier-config': 4.37.0(wp-prettier@3.0.3)
       cosmiconfig: 7.1.0
       eslint: 8.57.1(supports-color@8.1.1)
       eslint-config-prettier: 8.10.0(eslint@8.57.1(supports-color@8.1.1))
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.31.0)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)))(supports-color@8.1.1)(typescript@6.0.3)
       eslint-plugin-jsdoc: 46.10.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.57.1(supports-color@8.1.1))
-      eslint-plugin-playwright: 0.15.3(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))
+      eslint-plugin-playwright: 0.15.3(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))
       eslint-plugin-prettier: 5.2.1(@types/eslint@9.6.1)(eslint-config-prettier@8.10.0(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(wp-prettier@3.0.3)
       eslint-plugin-react: 7.37.1(eslint@8.57.1(supports-color@8.1.1))
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1(supports-color@8.1.1))
@@ -19013,7 +19016,7 @@ snapshots:
       requireindex: 1.2.0
     optionalDependencies:
       prettier: wp-prettier@3.0.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/eslint'
       - eslint-import-resolver-webpack
@@ -19234,17 +19237,17 @@ snapshots:
 
   '@wordpress/is-shallow-equal@5.37.0': {}
 
-  '@wordpress/jest-console@8.37.0(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))':
+  '@wordpress/jest-console@8.37.0(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)))':
     dependencies:
-      jest: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))
       jest-matcher-utils: 29.7.0
 
-  '@wordpress/jest-preset-default@12.37.0(@babel/core@7.25.7(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))(supports-color@8.1.1)':
+  '@wordpress/jest-preset-default@12.37.0(@babel/core@7.25.7(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.25.7(supports-color@8.1.1)
-      '@wordpress/jest-console': 8.37.0(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))
+      '@wordpress/jest-console': 8.37.0(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)))
       babel-jest: 29.7.0(@babel/core@7.25.7(supports-color@8.1.1))(supports-color@8.1.1)
-      jest: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -19323,9 +19326,9 @@ snapshots:
       '@wordpress/data': 10.37.0(react@18.3.1)
       react: 18.3.1
 
-  '@wordpress/npm-package-json-lint-config@5.37.0(npm-package-json-lint@6.4.0(supports-color@8.1.1)(typescript@5.9.3))':
+  '@wordpress/npm-package-json-lint-config@5.37.0(npm-package-json-lint@6.4.0(supports-color@8.1.1)(typescript@6.0.3))':
     dependencies:
-      npm-package-json-lint: 6.4.0(supports-color@8.1.1)(typescript@5.9.3)
+      npm-package-json-lint: 6.4.0(supports-color@8.1.1)(typescript@6.0.3)
 
   '@wordpress/patterns@2.37.0(@emotion/is-prop-valid@1.3.0)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)':
     dependencies:
@@ -19540,22 +19543,22 @@ snapshots:
       react: 18.3.1
       route-recognizer: 0.3.4
 
-  '@wordpress/scripts@31.2.0(@playwright/test@1.57.0)(@types/eslint@9.6.1)(@types/node@25.0.3)(@wordpress/env@10.37.0(@types/node@25.0.3)(supports-color@8.1.1))(babel-plugin-macros@3.1.0)(debug@4.4.3(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint-scss@6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3)))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(type-fest@4.39.1)(typescript@5.9.3)':
+  '@wordpress/scripts@31.2.0(@playwright/test@1.57.0)(@types/eslint@9.6.1)(@types/node@25.0.3)(@wordpress/env@10.37.0(@types/node@25.0.3)(supports-color@8.1.1))(babel-plugin-macros@3.1.0)(debug@4.4.3(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint-scss@6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3)))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))(type-fest@4.39.1)(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.25.7(supports-color@8.1.1)
       '@playwright/test': 1.57.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@4.39.1)(webpack-dev-server@4.15.2)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@svgr/webpack': 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
       '@wordpress/babel-preset-default': 8.37.0(supports-color@8.1.1)
       '@wordpress/browserslist-config': 6.37.0
       '@wordpress/dependency-extraction-webpack-plugin': 6.37.0(webpack@5.97.1)
       '@wordpress/e2e-test-utils-playwright': 1.37.0(@playwright/test@1.57.0)(supports-color@8.1.1)
-      '@wordpress/eslint-plugin': 23.0.0(@babel/core@7.25.7(supports-color@8.1.1))(@types/eslint@9.6.1)(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3)(wp-prettier@3.0.3)
-      '@wordpress/jest-preset-default': 12.37.0(@babel/core@7.25.7(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))(supports-color@8.1.1)
-      '@wordpress/npm-package-json-lint-config': 5.37.0(npm-package-json-lint@6.4.0(supports-color@8.1.1)(typescript@5.9.3))
+      '@wordpress/eslint-plugin': 23.0.0(@babel/core@7.25.7(supports-color@8.1.1))(@types/eslint@9.6.1)(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)))(supports-color@8.1.1)(typescript@6.0.3)(wp-prettier@3.0.3)
+      '@wordpress/jest-preset-default': 12.37.0(@babel/core@7.25.7(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)))(supports-color@8.1.1)
+      '@wordpress/npm-package-json-lint-config': 5.37.0(npm-package-json-lint@6.4.0(supports-color@8.1.1)(typescript@6.0.3))
       '@wordpress/postcss-plugins-preset': 5.37.0(postcss@8.5.6)
       '@wordpress/prettier-config': 4.37.0(wp-prettier@3.0.3)
-      '@wordpress/stylelint-config': 23.29.0(postcss@8.5.6)(stylelint-scss@6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3)))(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3))
+      '@wordpress/stylelint-config': 23.29.0(postcss@8.5.6)(stylelint-scss@6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3)))(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3))
       adm-zip: 0.5.16
       babel-jest: 29.7.0(@babel/core@7.25.7(supports-color@8.1.1))(supports-color@8.1.1)
       babel-loader: 9.2.1(@babel/core@7.25.7(supports-color@8.1.1))(webpack@5.97.1)
@@ -19572,7 +19575,7 @@ snapshots:
       expect-puppeteer: 4.4.0
       fast-glob: 3.3.3
       filenamify: 4.3.0
-      jest: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))
       jest-dev-server: 10.1.4(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       jest-environment-jsdom: 30.2.0(supports-color@8.1.1)
       jest-environment-node: 29.7.0
@@ -19581,7 +19584,7 @@ snapshots:
       merge-deep: 3.0.3
       mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
       minimist: 1.2.8
-      npm-package-json-lint: 6.4.0(supports-color@8.1.1)(typescript@5.9.3)
+      npm-package-json-lint: 6.4.0(supports-color@8.1.1)(typescript@6.0.3)
       npm-packlist: 3.0.0
       postcss: 8.5.6
       postcss-loader: 6.2.1(postcss@8.5.6)(webpack@5.97.1)
@@ -19597,7 +19600,7 @@ snapshots:
       sass-loader: 16.0.4(sass@1.81.0)(webpack@5.97.1)
       schema-utils: 4.2.0
       source-map-loader: 3.0.2(webpack@5.97.1)
-      stylelint: 16.9.0(supports-color@8.1.1)(typescript@5.9.3)
+      stylelint: 16.9.0(supports-color@8.1.1)(typescript@6.0.3)
       terser-webpack-plugin: 5.3.10(webpack@5.97.1)
       url-loader: 4.1.1(webpack@5.97.1)
       webpack: 5.97.1(webpack-cli@5.1.4)
@@ -19666,13 +19669,13 @@ snapshots:
     dependencies:
       change-case: 4.1.2
 
-  '@wordpress/stylelint-config@23.29.0(postcss@8.5.6)(stylelint-scss@6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3)))(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3))':
+  '@wordpress/stylelint-config@23.29.0(postcss@8.5.6)(stylelint-scss@6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3)))(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3))':
     dependencies:
-      '@stylistic/stylelint-plugin': 3.1.1(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3))
-      stylelint: 16.9.0(supports-color@8.1.1)(typescript@5.9.3)
-      stylelint-config-recommended: 14.0.1(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3))
-      stylelint-config-recommended-scss: 14.1.0(postcss@8.5.6)(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3))
-      stylelint-scss: 6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3))
+      '@stylistic/stylelint-plugin': 3.1.1(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3))
+      stylelint: 16.9.0(supports-color@8.1.1)(typescript@6.0.3)
+      stylelint-config-recommended: 14.0.1(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3))
+      stylelint-config-recommended-scss: 14.1.0(postcss@8.5.6)(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3))
+      stylelint-scss: 6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3))
     transitivePeerDependencies:
       - postcss
 
@@ -20823,23 +20826,23 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  cosmiconfig@8.3.6(typescript@5.9.3):
+  cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  cosmiconfig@9.0.0(typescript@5.9.3):
+  cosmiconfig@9.0.0(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   crc-32@1.2.2: {}
 
@@ -20848,13 +20851,13 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.5.2
 
-  create-jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -21543,22 +21546,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 8.57.1(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.9(supports-color@8.1.1)
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.31.0)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -21569,7 +21572,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.9(supports-color@8.1.1)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -21581,19 +21584,19 @@ snapshots:
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)))(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 8.57.1(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      jest: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      jest: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -21633,11 +21636,11 @@ snapshots:
       safe-regex-test: 1.0.3
       string.prototype.includes: 2.0.0
 
-  eslint-plugin-playwright@0.15.3(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1)):
+  eslint-plugin-playwright@0.15.3(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1)):
     dependencies:
       eslint: 8.57.1(supports-color@8.1.1)
     optionalDependencies:
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@8.57.1(supports-color@8.1.1))(jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)))(supports-color@8.1.1)(typescript@6.0.3)
 
   eslint-plugin-prettier@5.2.1(@types/eslint@9.6.1)(eslint-config-prettier@8.10.0(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(wp-prettier@3.0.3):
     dependencies:
@@ -23008,16 +23011,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)):
+  jest-cli@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      create-jest: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -23027,7 +23030,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)):
+  jest-config@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.28.5(supports-color@8.1.1)
       '@jest/test-sequencer': 29.7.0
@@ -23053,7 +23056,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.0.3
-      ts-node: 10.9.2(@types/node@25.0.3)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@25.0.3)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -23333,12 +23336,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -24008,7 +24011,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3):
+  msw@2.12.7(@types/node@25.0.3)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 5.1.8(@types/node@25.0.3)
       '@mswjs/interceptors': 0.40.0
@@ -24029,7 +24032,7 @@ snapshots:
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -24128,12 +24131,12 @@ snapshots:
 
   npm-normalize-package-bin@1.0.1: {}
 
-  npm-package-json-lint@6.4.0(supports-color@8.1.1)(typescript@5.9.3):
+  npm-package-json-lint@6.4.0(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
       ajv: 6.12.6
       ajv-errors: 1.0.1(ajv@6.12.6)
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.9.3)
+      cosmiconfig: 8.3.6(typescript@6.0.3)
       debug: 4.4.0(supports-color@8.1.1)
       globby: 11.1.0
       ignore: 5.3.2
@@ -25403,7 +25406,7 @@ snapshots:
 
   robots-parser@3.0.1: {}
 
-  rolldown-plugin-dts@0.27.14(rolldown@1.2.1)(typescript@5.9.3):
+  rolldown-plugin-dts@0.27.14(rolldown@1.2.1)(typescript@6.0.3):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
@@ -25413,7 +25416,7 @@ snapshots:
       yuku-codegen: 0.8.1
       yuku-parser: 0.8.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -25652,7 +25655,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@3.6.2(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(typescript@5.9.3):
+  shadcn@3.6.2(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
       '@antfu/ni': 25.0.0
       '@babel/core': 7.28.5(supports-color@8.1.1)
@@ -25663,7 +25666,7 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.25.1(supports-color@8.1.1)(zod@3.25.76)
       browserslist: 4.28.1
       commander: 14.0.2
-      cosmiconfig: 9.0.0(typescript@5.9.3)
+      cosmiconfig: 9.0.0(typescript@6.0.3)
       dedent: 1.7.1(babel-plugin-macros@3.1.0)
       deepmerge: 4.3.1
       diff: 8.0.2
@@ -25673,7 +25676,7 @@ snapshots:
       fuzzysort: 3.1.0
       https-proxy-agent: 7.0.6(supports-color@8.1.1)
       kleur: 4.1.5
-      msw: 2.12.7(@types/node@25.0.3)(typescript@5.9.3)
+      msw: 2.12.7(@types/node@25.0.3)(typescript@6.0.3)
       node-fetch: 3.3.2
       open: 11.0.0
       ora: 8.2.0
@@ -26104,20 +26107,20 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.1
 
-  stylelint-config-recommended-scss@14.1.0(postcss@8.5.6)(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3)):
+  stylelint-config-recommended-scss@14.1.0(postcss@8.5.6)(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.6)
-      stylelint: 16.9.0(supports-color@8.1.1)(typescript@5.9.3)
-      stylelint-config-recommended: 14.0.1(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3))
-      stylelint-scss: 6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3))
+      stylelint: 16.9.0(supports-color@8.1.1)(typescript@6.0.3)
+      stylelint-config-recommended: 14.0.1(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3))
+      stylelint-scss: 6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3))
     optionalDependencies:
       postcss: 8.5.6
 
-  stylelint-config-recommended@14.0.1(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3)):
+  stylelint-config-recommended@14.0.1(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3)):
     dependencies:
-      stylelint: 16.9.0(supports-color@8.1.1)(typescript@5.9.3)
+      stylelint: 16.9.0(supports-color@8.1.1)(typescript@6.0.3)
 
-  stylelint-scss@6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3)):
+  stylelint-scss@6.7.0(stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3)):
     dependencies:
       css-tree: 2.3.1
       is-plain-object: 5.0.0
@@ -26126,9 +26129,9 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
-      stylelint: 16.9.0(supports-color@8.1.1)(typescript@5.9.3)
+      stylelint: 16.9.0(supports-color@8.1.1)(typescript@6.0.3)
 
-  stylelint@16.9.0(supports-color@8.1.1)(typescript@5.9.3):
+  stylelint@16.9.0(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
@@ -26137,7 +26140,7 @@ snapshots:
       '@dual-bundle/import-meta-resolve': 4.1.0
       balanced-match: 2.0.0
       colord: 2.9.3
-      cosmiconfig: 9.0.0(typescript@5.9.3)
+      cosmiconfig: 9.0.0(typescript@6.0.3)
       css-functions-list: 3.2.3
       css-tree: 2.3.1
       debug: 4.4.3(supports-color@8.1.1)
@@ -26397,16 +26400,16 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  ts-api-utils@1.3.0(typescript@5.9.3):
+  ts-api-utils@1.3.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   ts-morph@26.0.0:
     dependencies:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
 
-  ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@25.0.3)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -26420,7 +26423,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -26439,7 +26442,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.22.14(typescript@5.9.3):
+  tsdown@0.22.14(typescript@6.0.3):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -26450,14 +26453,14 @@ snapshots:
       obug: 2.1.4
       picomatch: 4.0.5
       rolldown: 1.2.1
-      rolldown-plugin-dts: 0.27.14(rolldown@1.2.1)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.27.14(rolldown@1.2.1)(typescript@6.0.3)
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
       verkit: 0.3.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@typescript/native-preview'
       - '@volar/typescript'
@@ -26468,10 +26471,10 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsutils@3.21.0(typescript@5.9.3):
+  tsutils@3.21.0(typescript@6.0.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -26558,7 +26561,7 @@ snapshots:
     dependencies:
       ts-toolbelt: 9.6.0
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   uc.micro@1.0.6: {}
 

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../tsconfig.json",
 	"include": ["e2e"],
 	"compilerOptions": {
-		"lib": ["DOM", "DOM.Iterable", "ESNext"]
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
+		"types": ["node"]
 	}
 }

--- a/tools/e2e-utils/package.json
+++ b/tools/e2e-utils/package.json
@@ -25,8 +25,9 @@
 		"@wordpress/e2e-test-utils-playwright": "^1.37.0"
 	},
 	"devDependencies": {
+		"@types/node": "^25.0.3",
 		"rimraf": "^6.1.2",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	},
 	"scripts": {
 		"clean": "rimraf tsconfig.tsbuildinfo",

--- a/tools/e2e-utils/tsconfig.json
+++ b/tools/e2e-utils/tsconfig.json
@@ -1,4 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
-	"include": ["src"]
+	"include": ["src"],
+	"compilerOptions": {
+		"types": ["node"]
+	}
 }

--- a/tools/vite-wp-react/package.json
+++ b/tools/vite-wp-react/package.json
@@ -65,7 +65,7 @@
 		"@types/node": "^25.0.3",
 		"rimraf": "^6.1.2",
 		"tsdown": "^0.22.14",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vite": "^8.2.0",
 		"wireit": "^0.14.12"
 	},

--- a/tools/wpdev/package.json
+++ b/tools/wpdev/package.json
@@ -66,7 +66,7 @@
 		"oclif": "^4.22.61",
 		"rimraf": "^6.1.2",
 		"tsdown": "^0.22.14",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"wireit": "^0.14.12"
 	},
 	"oclif": {


### PR DESCRIPTION
Upgrades TypeScript from `5.9.3` to `6.0.3` across the monorepo.

TS 6 no longer auto-includes `@types/*` packages — `types` now defaults to empty unless it contains `"*"` — so every project that relied on ambient Node or Vite globals needs them declared explicitly:

- `packages/js/tsconfig.json`, `packages/js/shared-ui`, `test/` — `types: ["node"]` (`process.env.NODE_ENV` in `@wpsocio/utilities`, `node:*` imports in the Playwright config).
- `tools/e2e-utils` — `types: ["node"]` plus an explicit `@types/node` devDependency, which was previously resolved implicitly.
- `plugins/tsconfig.json` — `types: ["vite/client"]`, which declares the `*.scss` side-effect imports the entries rely on. TS 6 now errors on those (TS2882).

Also drops the now-deprecated `baseUrl` from `packages/js/ui`; its `paths` are already `./`-relative, so nothing else was needed. The tsup → tsdown switch in #330 means the bundler no longer forces `baseUrl` on the dts build, so no `ignoreDeprecations` escape hatch is needed anywhere.

No changeset: devDependency and tsconfig changes only, no shipped behaviour change.

`pnpm typecheck`, `pnpm build` and `pnpm lint:js` all pass, as do the `test/` and `premium/test/` projects. The lockfile diff is limited to the TypeScript bump and the new `@types/node` entry, and `pnpm install --frozen-lockfile` is clean.

### Remote Refs

<!--- REMOTE REFS START -->

premium: chore/upgrade-typescript-6

<!--- REMOTE REFS END -->
